### PR TITLE
Add start script to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/*"
   ],
   "scripts": {
+    "start": "pnpm --filter @ticketz/api start",
     "build": "pnpm -r build",
     "dev": "pnpm -r --parallel dev",
     "lint": "pnpm -r lint",


### PR DESCRIPTION
## Summary
- add a root-level start script that delegates to the API package so `pnpm start` runs the service

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da781a594c833288c6ac83f00db96b