### PR TITLE
Add root availability handlers

### DIFF
--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import type { AddressInfo } from 'net';
+import { Server } from 'http';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./routes/tickets', () => ({ ticketsRouter: express.Router() }));
+vi.mock('./routes/leads', () => ({ leadsRouter: express.Router() }));
+vi.mock('./routes/contacts', () => ({ contactsRouter: express.Router() }));
+vi.mock('./routes/auth', () => ({ authRouter: express.Router() }));
+vi.mock('./routes/webhooks', () => ({ webhooksRouter: express.Router() }));
+vi.mock('./routes/integrations', () => ({ integrationsRouter: express.Router() }));
+vi.mock('./routes/lead-engine', () => ({ leadEngineRouter: express.Router() }));
+vi.mock('./middleware/auth', () => ({ authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next() }));
+vi.mock('./middleware/error-handler', () => ({ errorHandler: (_err: unknown, _req: unknown, _res: unknown, next: () => void) => next() }));
+
+import { app } from './server';
+
+const startServer = () =>
+  new Promise<{ server: Server; url: string }>((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+
+const stopServer = (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+describe('root availability handlers', () => {
+  it('returns ok for GET /', async () => {
+    const { server, url } = await startServer();
+
+    try {
+      const response = await fetch(`${url}/`, { method: 'GET' });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ status: 'ok' });
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('returns ok for HEAD /', async () => {
+    const { server, url } = await startServer();
+
+    try {
+      const response = await fetch(`${url}/`, { method: 'HEAD' });
+
+      expect(response.status).toBe(200);
+    } finally {
+      await stopServer(server);
+    }
+  });
+});

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -130,6 +130,15 @@ io.on('connection', (socket) => {
 // Middleware de tratamento de erros (deve ser o último)
 app.use(errorHandler);
 
+// Root availability checks
+app.get('/', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+app.head('/', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
 // 404 handler
 app.use('*', (req, res) => {
   res.status(404).json({


### PR DESCRIPTION
## Summary
- add explicit GET and HEAD handlers on the API root that return a 200 with a simple status payload
- add vitest coverage that spins up the express app and asserts the new root endpoints respond with 200

## Testing
- pnpm --filter @ticketz/api test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68da8d2125f083329b9c5c732fc0e0cc