### PR TITLE
Add root availability endpoint for API

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -127,17 +127,16 @@ io.on('connection', (socket) => {
   });
 });
 
+// Root availability check
+app.get('/', (_req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    environment: NODE_ENV,
+  });
+});
+
 // Middleware de tratamento de erros (deve ser o último)
 app.use(errorHandler);
-
-// Root availability checks
-app.get('/', (_req, res) => {
-  res.status(200).json({ status: 'ok' });
-});
-
-app.head('/', (_req, res) => {
-  res.status(200).json({ status: 'ok' });
-});
 
 // 404 handler
 app.use('*', (req, res) => {


### PR DESCRIPTION
## Summary
- respond to GET requests on the API root with a 200 JSON payload so external health checks succeed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8c477d8883328b5aec9d994c479d