### PR TITLE
Ensure root HEAD handler returns accurate headers

### DIFF
--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -36,6 +36,11 @@ const stopServer = (server: Server) =>
   });
 
 describe('root availability handlers', () => {
+  const expectedPayload = {
+    status: 'ok',
+    environment: process.env.NODE_ENV || 'development',
+  };
+
   it('returns ok for GET /', async () => {
     const { server, url } = await startServer();
 
@@ -44,7 +49,7 @@ describe('root availability handlers', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({ status: 'ok' });
+      expect(body).toEqual(expectedPayload);
     } finally {
       await stopServer(server);
     }
@@ -57,6 +62,10 @@ describe('root availability handlers', () => {
       const response = await fetch(`${url}/`, { method: 'HEAD' });
 
       expect(response.status).toBe(200);
+      expect(response.headers.get('content-length')).toBe(
+        Buffer.byteLength(JSON.stringify(expectedPayload)).toString(),
+      );
+      expect(response.headers.get('content-type')).toContain('application/json');
     } finally {
       await stopServer(server);
     }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -128,11 +128,25 @@ io.on('connection', (socket) => {
 });
 
 // Root availability check
+const rootAvailabilityPayload = {
+  status: 'ok',
+  environment: NODE_ENV,
+};
+
 app.get('/', (_req, res) => {
-  res.status(200).json({
-    status: 'ok',
-    environment: NODE_ENV,
-  });
+  res.status(200).json(rootAvailabilityPayload);
+});
+
+app.head('/', (_req, res) => {
+  const payloadString = JSON.stringify(rootAvailabilityPayload);
+
+  res
+    .status(200)
+    .set({
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Length': Buffer.byteLength(payloadString).toString(),
+    })
+    .end();
 });
 
 // Middleware de tratamento de erros (deve ser o último)


### PR DESCRIPTION
## Summary
- share the root availability payload between GET and HEAD handlers
- compute the HEAD response content-length from the JSON payload
- update the server tests to cover the adjusted GET payload and HEAD headers

## Testing
- pnpm vitest run src/server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dab88b52b083328d377168e8e47305