### PR TITLE
chore(api): build shared workspaces before api build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,10 @@
   "description": "API REST para o sistema Ticketz-LeadEngine",
   "main": "dist/server.js",
   "scripts": {
-    "build": "prisma generate --schema=../../prisma/schema.prisma && tsup",
+    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/shared --filter @ticketz/storage --filter @ticketz/integrations build",
+    "build": "pnpm run build:dependencies && prisma generate --schema=../../prisma/schema.prisma && tsup",
     "dev": "tsx watch src/server.ts",
+    "prestart": "pnpm run build:dependencies",
     "start": "node dist/server.js",
     "test": "vitest",
     "test:watch": "vitest --watch",


### PR DESCRIPTION
## Summary
- add a build:dependencies helper to compile shared workspace packages before the API build runs
- update the API build and prestart scripts so Render deploys compile shared packages before tsup and runtime

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68dabb7ff5d883328cb70d0d79173a2b