### PR TITLE
feat: allow configuring API log file paths

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -54,6 +54,7 @@ nano .env
 - `JWT_SECRET`: Gere com `openssl rand -base64 64`
 - `FRONTEND_URL`: Seu domínio real
 - `VITE_API_URL`: URL da API (ex: https://api.seudominio.com)
+- `LOG_FILE` / `LOG_FILE_ERROR`: Caminhos absolutos ou relativos para os arquivos de log combinado e de erros da API. Garanta que apontem para um diretório persistente.
 
 ### 2. Configurar Domínio (Opcional)
 
@@ -206,6 +207,8 @@ docker compose -f docker-compose.prod.yml logs api
 docker compose -f docker-compose.prod.yml logs web
 docker compose -f docker-compose.prod.yml logs postgres
 ```
+
+> ℹ️ A API grava logs de aplicação e de erros nos caminhos definidos pelas variáveis `LOG_FILE` e `LOG_FILE_ERROR`. Caso utilize caminhos personalizados (ex.: `/var/log/ticketz/api.log`), os diretórios serão criados automaticamente durante a inicialização do serviço.
 
 ### 2. Métricas
 

--- a/apps/api/src/config/logger.ts
+++ b/apps/api/src/config/logger.ts
@@ -7,6 +7,27 @@ if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
 
+const resolveLogFilePath = (envPath: string | undefined, fallbackFileName: string) => {
+  if (envPath && envPath.trim().length > 0) {
+    return path.resolve(process.cwd(), envPath);
+  }
+
+  return path.join(logsDir, fallbackFileName);
+};
+
+const ensureDirectoryForFile = (filePath: string) => {
+  const directory = path.dirname(filePath);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+};
+
+const combinedLogPath = resolveLogFilePath(process.env.LOG_FILE, 'combined.log');
+const errorLogPath = resolveLogFilePath(process.env.LOG_FILE_ERROR, 'error.log');
+
+ensureDirectoryForFile(combinedLogPath);
+ensureDirectoryForFile(errorLogPath);
+
 const { combine, timestamp, errors, json, simple, colorize } = winston.format;
 
 // Configuração do logger
@@ -22,15 +43,16 @@ export const logger = winston.createLogger({
     environment: process.env.NODE_ENV || 'development',
   },
   transports: [
-    // Arquivo para todos os logs
+    // Arquivo para logs de erro
     new winston.transports.File({
-      filename: 'logs/error.log',
+      filename: errorLogPath,
       level: 'error',
       maxsize: 5242880, // 5MB
       maxFiles: 5,
     }),
+    // Arquivo com todos os logs
     new winston.transports.File({
-      filename: 'logs/combined.log',
+      filename: combinedLogPath,
       maxsize: 5242880, // 5MB
       maxFiles: 5,
     }),

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,6 +39,8 @@ WHATSAPP_BROKER_URL=https://baileys-acessuswpp.onrender.com
 WHATSAPP_BROKER_API_KEY=<API_KEY>
 LEAD_ENGINE_BROKER_BASE_URL=https://lead-engine-production.up.railway.app
 LEAD_ENGINE_BASIC_TOKEN=bGVhZC1...
+LOG_FILE=logs/api/combined.log
+LOG_FILE_ERROR=logs/api/error.log
 ```
 
 > Em produção substitua os defaults por credenciais reais e, se necessário, habilite SSL do banco (`DATABASE_SSL=true`).
@@ -79,5 +81,6 @@ docker compose down -v
 - `docker compose logs -f api`
 - `docker compose logs -f web`
 - `docker compose exec api sh` (para abrir shell dentro do container)
+- Os caminhos configurados em `LOG_FILE` e `LOG_FILE_ERROR` serão criados automaticamente caso não existam. Em produção considere apontá-los para um volume persistente (ex.: `/var/log/ticketz/combined.log`).
 
 Mantenha o arquivo `.env` fora do controle de versão (listado em `.gitignore`) e lembre-se de girar senhas/tokens ao mover para produção.


### PR DESCRIPTION
## Summary
- allow configuring API log transports via LOG_FILE and LOG_FILE_ERROR environment variables
- ensure target directories are created automatically for combined and error logs
- update deployment documentation to describe the new log configuration options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad97bade483328b68556b752cba37