### PR TITLE
Parametrize API rate limiting via environment variables

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -43,10 +43,26 @@ const io = new SocketIOServer(server, {
 const PORT = process.env.PORT || 4000;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
+// Rate limit configuration
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 100;
+
+const parsedRateLimitWindowMs = Number(process.env.RATE_LIMIT_WINDOW_MS);
+const rateLimitWindowMs =
+  Number.isFinite(parsedRateLimitWindowMs) && parsedRateLimitWindowMs > 0
+    ? parsedRateLimitWindowMs
+    : DEFAULT_RATE_LIMIT_WINDOW_MS;
+
+const parsedRateLimitMaxRequests = Number(process.env.RATE_LIMIT_MAX_REQUESTS);
+const rateLimitMaxRequests =
+  Number.isInteger(parsedRateLimitMaxRequests) && parsedRateLimitMaxRequests > 0
+    ? parsedRateLimitMaxRequests
+    : DEFAULT_RATE_LIMIT_MAX_REQUESTS;
+
 // Rate limiting
 const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutos
-  max: 100, // máximo 100 requests por IP por janela
+  windowMs: rateLimitWindowMs, // 15 minutos por padrão
+  max: rateLimitMaxRequests, // máximo 100 requests por IP por janela por padrão
   message: 'Too many requests from this IP, please try again later.',
 });
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,9 +39,13 @@ WHATSAPP_BROKER_URL=https://baileys-acessuswpp.onrender.com
 WHATSAPP_BROKER_API_KEY=<API_KEY>
 LEAD_ENGINE_BROKER_BASE_URL=https://lead-engine-production.up.railway.app
 LEAD_ENGINE_BASIC_TOKEN=bGVhZC1...
+RATE_LIMIT_WINDOW_MS=900000 # opcional (padrão: 15 minutos)
+RATE_LIMIT_MAX_REQUESTS=100 # opcional (padrão: 100 requisições)
 ```
 
 > Em produção substitua os defaults por credenciais reais e, se necessário, habilite SSL do banco (`DATABASE_SSL=true`).
+
+As variáveis `RATE_LIMIT_WINDOW_MS` e `RATE_LIMIT_MAX_REQUESTS` permitem ajustar a janela e o número máximo de requisições por IP aplicados pelo middleware de rate limiting da API. Valores não numéricos ou inválidos são ignorados e os padrões (15 minutos / 100 requisições) são utilizados.
 
 ## 4. Subindo os serviços
 


### PR DESCRIPTION
## Summary
- allow configuring the API rate limiter through RATE_LIMIT_WINDOW_MS and RATE_LIMIT_MAX_REQUESTS environment variables with sane defaults
- document the new rate limit configuration options in the Docker operations guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad96e83d88332955fdeb7e6d2bd3e