### PR TITLE
feat(web): add demo auth login manager

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -112,6 +112,21 @@ Caso utilize o Render.com para hospedar a API como serviço web, configure os co
 
 > ℹ️ O script `build` da API dispara `build:dependencies` (com `pnpm --dir ../.. -r --filter ... run build`) antes do `tsup`. Assim, os diretórios `dist` dos pacotes `@ticketz/{core,shared,storage,integrations}` são gerados antes do `node dist/server.js`, evitando erros de resolução de módulos nas etapas de deploy e runtime.
 
+#### Variáveis de ambiente obrigatórias no Render
+
+Além das variáveis já definidas na seção de configuração (como `DATABASE_URL`, `JWT_SECRET`, `VITE_API_URL`, etc.), configure explicitamente no Render:
+
+- **Serviço da API**
+  - `JWT_SECRET`, `POSTGRES_PASSWORD`, `DATABASE_URL` (ou parâmetros individuais), `REDIS_URL` (quando aplicável).
+  - Garanta que exista um operador demo com e-mail/senha conhecidos rodando `pnpm --filter @ticketz/api db:seed` após provisionar o banco ou criando o usuário manualmente.
+- **Serviço Web (frontend)**
+  - `VITE_API_URL`: URL pública da API (ex.: `https://api.seudominio.com`).
+  - `VITE_DEMO_TENANT_ID`: tenant padrão para o operador demo (ex.: `demo-tenant`).
+  - `VITE_DEMO_OPERATOR_EMAIL` e `VITE_DEMO_OPERATOR_PASSWORD`: credenciais que serão pré-preenchidas no modal de login do frontend.
+  - (Opcional) `VITE_API_AUTH_TOKEN`: token JWT estático usado apenas como fallback caso nenhuma sessão seja gerada no navegador.
+
+> 🔐 Caso prefira não armazenar a senha do operador em variáveis do Render, gere manualmente um JWT válido com o comando `pnpm --filter @ticketz/api exec ts-node scripts/generate-jwt.ts --email operador@exemplo.com` e preencha o valor em `VITE_API_AUTH_TOKEN`. Sem o token ou o usuário seedado, o modal de autenticação não conseguirá criar a sessão demo.
+
 ## 🔍 Verificação
 
 ### 1. Verificar Status dos Serviços

--- a/apps/web/src/components/DemoAuthDialog.jsx
+++ b/apps/web/src/components/DemoAuthDialog.jsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from 'react';
+import { LogIn } from 'lucide-react';
+import { Button } from '@/components/ui/button.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Label } from '@/components/ui/label.jsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.jsx';
+import {
+  getAuthToken,
+  getTenantId,
+  loginWithCredentials,
+  onAuthTokenChange,
+  onTenantIdChange,
+} from '@/lib/auth.js';
+
+const defaultEmail = import.meta.env.VITE_DEMO_OPERATOR_EMAIL || '';
+const defaultPassword = import.meta.env.VITE_DEMO_OPERATOR_PASSWORD || '';
+const fallbackTenant =
+  import.meta.env.VITE_DEMO_TENANT_ID || import.meta.env.VITE_API_TENANT_ID || import.meta.env.VITE_TENANT_ID || '';
+
+const initialTenant = () => getTenantId() || fallbackTenant;
+
+const sanitizeTenant = (value) => value?.trim().toLowerCase() || '';
+
+export default function DemoAuthDialog() {
+  const [open, setOpen] = useState(false);
+  const [hasToken, setHasToken] = useState(() => Boolean(getAuthToken()));
+  const [activeTenant, setActiveTenant] = useState(() => sanitizeTenant(initialTenant()));
+  const [formData, setFormData] = useState(() => ({
+    email: defaultEmail,
+    password: defaultPassword,
+    tenantId: sanitizeTenant(initialTenant()),
+  }));
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    const unsubToken = onAuthTokenChange((token) => {
+      setHasToken(Boolean(token));
+    });
+    const unsubTenant = onTenantIdChange((tenant) => {
+      const normalized = sanitizeTenant(tenant);
+      setActiveTenant(normalized);
+      setFormData((previous) => {
+        if (previous.tenantId) {
+          return previous;
+        }
+        return { ...previous, tenantId: normalized };
+      });
+    });
+    return () => {
+      unsubToken();
+      unsubTenant();
+    };
+  }, []);
+
+  const handleChange = (field) => (event) => {
+    const value = field === 'tenantId' ? sanitizeTenant(event.target.value) : event.target.value;
+    setFormData((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError('');
+    setSuccess('');
+    try {
+      const payload = {
+        email: formData.email,
+        password: formData.password,
+        tenantId: sanitizeTenant(formData.tenantId),
+      };
+      await loginWithCredentials(payload);
+      setSuccess('Login realizado com sucesso. Token ativo para chamadas subsequentes.');
+      setOpen(false);
+    } catch (submitError) {
+      setError(submitError?.message || 'Falha ao autenticar. Verifique as credenciais.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const statusLabel = useMemo(() => {
+    if (hasToken) {
+      return activeTenant ? `Sessão ativa (${activeTenant})` : 'Sessão ativa';
+    }
+    return 'Sem sessão ativa';
+  }, [hasToken, activeTenant]);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => {
+      setOpen(next);
+      if (next) {
+        setError('');
+        setSuccess('');
+        setFormData((previous) => ({
+          ...previous,
+          tenantId: previous.tenantId || sanitizeTenant(initialTenant()),
+        }));
+      }
+    }}>
+      <DialogTrigger asChild>
+        <Button variant={hasToken ? 'secondary' : 'default'} size="sm" className="gap-2">
+          <LogIn className="h-4 w-4" />
+          {hasToken ? 'Atualizar sessão demo' : 'Login demo'}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Autenticar operador demo</DialogTitle>
+          <DialogDescription>
+            Informe as credenciais do operador demo para gerar um token de API e persistir o tenant ativo no navegador.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="demo-tenant">Tenant</Label>
+            <Input
+              id="demo-tenant"
+              autoComplete="off"
+              value={formData.tenantId}
+              onChange={handleChange('tenantId')}
+              placeholder="ex.: demo-tenant"
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Tenant atual: {activeTenant || 'não definido'}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="demo-email">E-mail</Label>
+            <Input
+              id="demo-email"
+              type="email"
+              autoComplete="username"
+              value={formData.email}
+              onChange={handleChange('email')}
+              placeholder="operador@exemplo.com"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="demo-password">Senha</Label>
+            <Input
+              id="demo-password"
+              type="password"
+              autoComplete="current-password"
+              value={formData.password}
+              onChange={handleChange('password')}
+              placeholder="••••••••"
+              required
+            />
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {success ? <p className="text-sm text-emerald-500">{success}</p> : null}
+          <DialogFooter className="flex-row-reverse justify-between gap-2">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Autenticando...' : 'Gerar token'}
+            </Button>
+            <p className="text-xs text-muted-foreground">{statusLabel}</p>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -20,6 +20,7 @@ import { Badge } from '@/components/ui/badge.jsx';
 import './Layout.css';
 import HealthIndicator from './HealthIndicator.jsx';
 import TenantSelector from './TenantSelector.jsx';
+import DemoAuthDialog from './DemoAuthDialog.jsx';
 
 const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding }) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -123,6 +124,7 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
           </div>
 
           <div className="header-right" style={{ gap: 12 }}>
+            <DemoAuthDialog />
             <TenantSelector />
             <Button variant="ghost" size="sm" className="notification-btn">
               <Bell className="h-5 w-5" />

--- a/apps/web/src/components/TenantSelector.jsx
+++ b/apps/web/src/components/TenantSelector.jsx
@@ -1,27 +1,22 @@
 import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input.jsx';
+import { getTenantId, onTenantIdChange, setTenantId } from '@/lib/auth.js';
 
 export default function TenantSelector({ onChange }) {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(() => getTenantId() || '');
 
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem('tenantId');
-      if (saved) setValue(saved);
-    } catch (error) {
-      console.debug('Não foi possível ler tenant salvo', error);
-    }
+    const unsubscribe = onTenantIdChange((nextTenant) => {
+      setValue(nextTenant || '');
+    });
+    return () => unsubscribe();
   }, []);
 
   const apply = (next) => {
     setValue(next);
-    try {
-      if (next) localStorage.setItem('tenantId', next);
-      else localStorage.removeItem('tenantId');
-    } catch (error) {
-      console.debug('Não foi possível atualizar tenant salvo', error);
-    }
-    onChange?.(next || undefined);
+    const applied = next || undefined;
+    setTenantId(applied);
+    onChange?.(applied);
   };
 
   return (

--- a/apps/web/src/lib/auth.js
+++ b/apps/web/src/lib/auth.js
@@ -1,0 +1,225 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
+
+const TOKEN_STORAGE_KEY = 'leadengine_auth_token';
+const TENANT_STORAGE_KEY = 'tenantId';
+
+const storageCandidates = [
+  () => (typeof window !== 'undefined' ? window.localStorage : undefined),
+  () => (typeof window !== 'undefined' ? window.sessionStorage : undefined),
+];
+
+const tokenSubscribers = new Set();
+const tenantSubscribers = new Set();
+
+const safeCall = (fn, ...args) => {
+  try {
+    return fn(...args);
+  } catch (error) {
+    console.debug('Auth storage operation failed', error);
+    return undefined;
+  }
+};
+
+const readFromStorage = (key) => {
+  for (const resolver of storageCandidates) {
+    const storage = safeCall(resolver);
+    if (!storage) continue;
+    const value = safeCall(() => storage.getItem(key));
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const writeToStorage = (key, value) => {
+  let persisted = false;
+  for (const resolver of storageCandidates) {
+    const storage = safeCall(resolver);
+    if (!storage) continue;
+    if (typeof value === 'string' && value.length > 0) {
+      persisted = safeCall(() => storage.setItem(key, value)) === undefined || persisted;
+    } else {
+      persisted = safeCall(() => storage.removeItem(key)) === undefined || persisted;
+    }
+    if (persisted) break;
+  }
+  return persisted;
+};
+
+let currentToken = readFromStorage(TOKEN_STORAGE_KEY);
+let currentTenantId = readFromStorage(TENANT_STORAGE_KEY) || undefined;
+
+const notifyTokenSubscribers = () => {
+  tokenSubscribers.forEach((callback) => {
+    try {
+      callback(currentToken);
+    } catch (error) {
+      console.error('Auth token subscriber failed', error);
+    }
+  });
+};
+
+const notifyTenantSubscribers = () => {
+  tenantSubscribers.forEach((callback) => {
+    try {
+      callback(currentTenantId);
+    } catch (error) {
+      console.error('Tenant subscriber failed', error);
+    }
+  });
+};
+
+const commitToken = (token, { persist = true, notify = true } = {}) => {
+  const normalized = typeof token === 'string' ? token.trim() : undefined;
+  currentToken = normalized && normalized.length > 0 ? normalized : undefined;
+  if (persist) {
+    if (currentToken) {
+      writeToStorage(TOKEN_STORAGE_KEY, currentToken);
+    } else {
+      writeToStorage(TOKEN_STORAGE_KEY, undefined);
+    }
+  }
+  if (notify) {
+    notifyTokenSubscribers();
+  }
+};
+
+const commitTenantId = (tenantId, { persist = true, notify = true } = {}) => {
+  const normalized = typeof tenantId === 'string' ? tenantId.trim() : undefined;
+  currentTenantId = normalized && normalized.length > 0 ? normalized : undefined;
+  if (persist) {
+    if (currentTenantId) {
+      writeToStorage(TENANT_STORAGE_KEY, currentTenantId);
+    } else {
+      writeToStorage(TENANT_STORAGE_KEY, undefined);
+    }
+  }
+  if (notify) {
+    notifyTenantSubscribers();
+  }
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key === TOKEN_STORAGE_KEY) {
+      commitToken(event.newValue ?? undefined, { persist: false, notify: true });
+    }
+    if (event.key === TENANT_STORAGE_KEY) {
+      commitTenantId(event.newValue ?? undefined, { persist: false, notify: true });
+    }
+  });
+}
+
+const buildUrl = (path) => {
+  if (!path) {
+    return API_BASE_URL || '';
+  }
+  if (/^https?:/i.test(path)) {
+    return path;
+  }
+  if (API_BASE_URL) {
+    return `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+  }
+  return path;
+};
+
+export const getAuthToken = () => currentToken;
+
+export const onAuthTokenChange = (callback) => {
+  if (typeof callback !== 'function') return () => {};
+  tokenSubscribers.add(callback);
+  return () => tokenSubscribers.delete(callback);
+};
+
+export const setAuthToken = (token) => {
+  commitToken(token, { persist: true, notify: true });
+  return currentToken;
+};
+
+export const clearAuthToken = () => {
+  commitToken(undefined, { persist: true, notify: true });
+};
+
+export const getTenantId = () => currentTenantId;
+
+export const onTenantIdChange = (callback) => {
+  if (typeof callback !== 'function') return () => {};
+  tenantSubscribers.add(callback);
+  return () => tenantSubscribers.delete(callback);
+};
+
+export const setTenantId = (tenantId) => {
+  commitTenantId(tenantId, { persist: true, notify: true });
+  return currentTenantId;
+};
+
+export const clearTenantId = () => {
+  commitTenantId(undefined, { persist: true, notify: true });
+};
+
+const parseLoginResponse = async (response) => {
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload?.success === false) {
+    const message = payload?.error?.message || payload?.message || response.statusText;
+    throw new Error(message || 'Falha ao autenticar na API');
+  }
+  return payload;
+};
+
+export const loginWithCredentials = async ({ email, password, tenantId } = {}) => {
+  const requestBody = {
+    email,
+    password,
+  };
+  if (tenantId) {
+    requestBody.tenantId = tenantId;
+  }
+
+  const response = await fetch(buildUrl('/api/auth/login'), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify(requestBody),
+  });
+
+  const payload = await parseLoginResponse(response);
+  const token =
+    payload?.token || payload?.accessToken || payload?.data?.token || payload?.jwt || payload?.data?.accessToken;
+  if (!token) {
+    throw new Error('A resposta da API não retornou um token de autenticação');
+  }
+
+  const resolvedTenant = tenantId || payload?.tenantId || payload?.tenant?.id;
+
+  commitToken(token, { persist: true, notify: true });
+  if (resolvedTenant) {
+    commitTenantId(resolvedTenant, { persist: true, notify: true });
+  }
+
+  return {
+    token,
+    tenantId: getTenantId(),
+    payload,
+  };
+};
+
+export const logout = () => {
+  clearAuthToken();
+};
+
+export default {
+  getAuthToken,
+  setAuthToken,
+  clearAuthToken,
+  onAuthTokenChange,
+  getTenantId,
+  setTenantId,
+  clearTenantId,
+  onTenantIdChange,
+  loginWithCredentials,
+  logout,
+};


### PR DESCRIPTION
## Summary
- add a browser auth helper to persist tokens/tenant IDs and feed API requests
- provide a demo-operator login dialog wired into the layout and tenant selector
- document Render environment variables and demo user/JWT requirements

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68dae4f5f6048332b156d3b8f24691aa