### PR TITLE
feat: add lead engine campaign routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ PUT    /api/leads/:id
 DELETE /api/leads/:id
 ```
 
+#### Lead Engine
+```
+GET    /api/lead-engine/campaigns?agreementId={id}&status=ACTIVE,PAUSED
+POST   /api/lead-engine/campaigns
+GET    /api/lead-engine/agreements
+GET    /api/lead-engine/agreements/available
+```
+
+> `status` aceita múltiplos valores separados por vírgula ou repetidos na query string
+> (por exemplo: `status=ACTIVE,PAUSED` ou `status=ACTIVE&status=PAUSED`).
+> O payload de criação exige `agreementId`, `instanceId` e `name`, além de um `status`
+> opcional (`ACTIVE`, `PAUSED` ou `COMPLETED`).
+
 #### WhatsApp
 ```
 GET    /api/integrations/whatsapp/instances

--- a/apps/api/src/routes/lead-engine.test.ts
+++ b/apps/api/src/routes/lead-engine.test.ts
@@ -1,0 +1,185 @@
+import express from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CampaignStatus, resetCampaignStore } from '@ticketz/storage';
+
+import { leadEngineRouter } from './lead-engine';
+import { errorHandler } from '../middleware/error-handler';
+
+const startTestServer = () =>
+  new Promise<{ server: Server; url: string }>((resolve) => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/lead-engine', leadEngineRouter);
+    app.use(errorHandler);
+
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+
+const stopTestServer = (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+describe('Lead Engine campaigns routes', () => {
+  beforeEach(() => {
+    resetCampaignStore();
+  });
+
+  it('creates or reactivates a campaign', async () => {
+    const { server, url } = await startTestServer();
+
+    try {
+      const response = await fetch(`${url}/api/lead-engine/campaigns`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          agreementId: 'agreement-1',
+          instanceId: 'instance-1',
+          name: 'New Campaign',
+          status: CampaignStatus.PAUSED,
+        }),
+      });
+
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        agreementId: 'agreement-1',
+        instanceId: 'instance-1',
+        name: 'New Campaign',
+        status: CampaignStatus.PAUSED,
+      });
+      expect(body.data.id).toBeDefined();
+      expect(body.data.tenantId).toBe('tenant-123');
+
+      // Reactivate the same campaign
+      const secondResponse = await fetch(`${url}/api/lead-engine/campaigns`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          agreementId: 'agreement-1',
+          instanceId: 'instance-1',
+          name: 'Updated Campaign Name',
+          status: CampaignStatus.ACTIVE,
+        }),
+      });
+
+      const secondBody = await secondResponse.json();
+
+      expect(secondResponse.status).toBe(200);
+      expect(secondBody.success).toBe(true);
+      expect(secondBody.data.id).toBe(body.data.id);
+      expect(secondBody.data.name).toBe('Updated Campaign Name');
+      expect(secondBody.data.status).toBe(CampaignStatus.ACTIVE);
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('lists campaigns filtered by agreement and status', async () => {
+    const { server, url } = await startTestServer();
+
+    try {
+      // Seed campaigns
+      const createCampaign = async (payload: Record<string, unknown>) => {
+        const response = await fetch(`${url}/api/lead-engine/campaigns`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-tenant-id': 'tenant-xyz',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(200);
+        const result = await response.json();
+        expect(result.success).toBe(true);
+        return result;
+      };
+
+      await createCampaign({
+        agreementId: 'agreement-a',
+        instanceId: 'instance-1',
+        name: 'Active Campaign',
+        status: CampaignStatus.ACTIVE,
+      });
+      await createCampaign({
+        agreementId: 'agreement-a',
+        instanceId: 'instance-2',
+        name: 'Paused Campaign',
+        status: CampaignStatus.PAUSED,
+      });
+      await createCampaign({
+        agreementId: 'agreement-b',
+        instanceId: 'instance-3',
+        name: 'Completed Campaign',
+        status: CampaignStatus.COMPLETED,
+      });
+
+      const response = await fetch(
+        `${url}/api/lead-engine/campaigns?agreementId=agreement-a&status=${encodeURIComponent(
+          'ACTIVE,PAUSED'
+        )}`,
+        {
+          headers: {
+            'x-tenant-id': 'tenant-xyz',
+          },
+        }
+      );
+
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(body.data).toHaveLength(2);
+      const statuses = body.data.map((campaign: { status: CampaignStatus }) => campaign.status);
+      expect(statuses).toEqual([CampaignStatus.ACTIVE, CampaignStatus.PAUSED]);
+      const agreements = body.data.map((campaign: { agreementId: string }) => campaign.agreementId);
+      expect(new Set(agreements)).toEqual(new Set(['agreement-a']));
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('validates required fields on POST /campaigns', async () => {
+    const { server, url } = await startTestServer();
+
+    try {
+      const response = await fetch(`${url}/api/lead-engine/campaigns`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({}),
+      });
+
+      const text = await response.text();
+      expect(response.status, text).toBe(400);
+      const body = JSON.parse(text);
+      expect(body.error?.code).toBe('VALIDATION_ERROR');
+      expect(body.error?.details).toBeDefined();
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+const resolvePackageRoot = (pkg: string) => path.resolve(__dirname, `../../packages/${pkg}/src`);
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: [
+      { find: '@ticketz/core', replacement: path.join(resolvePackageRoot('core'), 'index.ts') },
+      { find: '@ticketz/core/', replacement: `${resolvePackageRoot('core')}/` },
+      { find: '@ticketz/shared', replacement: path.join(resolvePackageRoot('shared'), 'index.ts') },
+      { find: '@ticketz/shared/', replacement: `${resolvePackageRoot('shared')}/` },
+      { find: '@ticketz/storage', replacement: path.join(resolvePackageRoot('storage'), 'index.ts') },
+      { find: '@ticketz/storage/', replacement: `${resolvePackageRoot('storage')}/` },
+      { find: '@ticketz/integrations', replacement: path.join(resolvePackageRoot('integrations'), 'index.ts') },
+      { find: '@ticketz/integrations/', replacement: `${resolvePackageRoot('integrations')}/` },
+    ],
+  },
+});

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -18,4 +18,5 @@ export {
   findCampaignById,
   findActiveCampaign,
   listCampaigns,
+  resetCampaignStore,
 } from './repositories/campaign-repository';


### PR DESCRIPTION
## Summary
- add GET/POST /api/lead-engine/campaigns routes backed by the shared in-memory storage and consistent logging
- expose resetCampaignStore and update Vitest config to resolve workspace package aliases for testing
- cover the new endpoints with integration tests and document campaign routes in the API README

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68dae4e956b883329893fa343988e32b