### PR TITLE
Allow JWT fallback for demo WhatsApp integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 # JWT
 JWT_SECRET=your-super-secret-jwt-key
 JWT_EXPIRES_IN=7d
+AUTH_ALLOW_JWT_FALLBACK=true
 
 # Database (quando configurar)
 DATABASE_URL="postgresql://user:password@localhost:5432/ticketz"
@@ -112,6 +113,7 @@ LOG_LEVEL=info
 ```
 
 > **Dica:** Defina `CORS_ALLOWED_ORIGINS` com uma lista de domínios adicionais (separados por vírgula) quando precisar liberar múltiplos frontends hospedados simultaneamente. O valor de `FRONTEND_URL` continua sendo utilizado como origem principal.
+> **Demo:** `AUTH_ALLOW_JWT_FALLBACK` permite aceitar tokens JWT válidos mesmo quando o usuário não existe no banco (útil em ambientes de demonstração). Defina como `false` em produção para exigir usuários persistidos.
 
 #### Frontend (apps/web/.env.local)
 ```env


### PR DESCRIPTION
## Summary
- add a configurable JWT payload fallback in the auth middleware so demo tokens without persisted users can access WhatsApp endpoints
- normalize tenant resolution to honor x-tenant-id headers during access checks
- document the new AUTH_ALLOW_JWT_FALLBACK environment flag for backend deployments

## Testing
- pnpm --filter @ticketz/api build


------
https://chatgpt.com/codex/tasks/task_e_68daea85d798833287a34f5a6afabad1