### PR TITLE
Ensure tenant from login is persisted and used

### DIFF
--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -37,11 +37,20 @@ const baseHeaders = () => {
   };
 
   // Prioriza seleção feita pelo usuário (persistida no navegador)
-  let tenantId =
-    persistedTenantId ||
-    import.meta.env.VITE_API_TENANT_ID ||
-    import.meta.env.VITE_TENANT_ID ||
-    'demo-tenant';
+  let tenantId = persistedTenantId;
+
+  if (!tenantId) {
+    const envTenant =
+      import.meta.env.VITE_API_TENANT_ID ?? import.meta.env.VITE_TENANT_ID ?? undefined;
+    if (typeof envTenant === 'string') {
+      const normalized = envTenant.trim();
+      tenantId = normalized.length > 0 ? normalized : undefined;
+    }
+  }
+
+  if (!tenantId) {
+    tenantId = 'demo-tenant';
+  }
   if (tenantId) {
     headers['x-tenant-id'] = tenantId;
   }

--- a/apps/web/src/lib/auth.js
+++ b/apps/web/src/lib/auth.js
@@ -193,12 +193,19 @@ export const loginWithCredentials = async ({ email, password, tenantId } = {}) =
     throw new Error('A resposta da API não retornou um token de autenticação');
   }
 
-  const resolvedTenant = tenantId || payload?.tenantId || payload?.tenant?.id;
+  const resolvedTenant =
+    tenantId ||
+    payload?.tenantId ||
+    payload?.tenant?.id ||
+    payload?.user?.tenantId ||
+    payload?.user?.tenant?.id ||
+    payload?.data?.tenantId ||
+    payload?.data?.tenant?.id ||
+    payload?.data?.user?.tenantId ||
+    payload?.data?.user?.tenant?.id;
 
   commitToken(token, { persist: true, notify: true });
-  if (resolvedTenant) {
-    commitTenantId(resolvedTenant, { persist: true, notify: true });
-  }
+  commitTenantId(resolvedTenant, { persist: true, notify: true });
 
   return {
     token,


### PR DESCRIPTION
## Summary
- expand tenant resolution during login to persist tenant IDs provided in different payload shapes
- adjust API header tenant resolution to only fall back to the demo tenant when nothing is persisted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db15e8041c8332b9cb9929f6711330