### PR TITLE
Use WhatsApp broker start endpoint and update Render docs

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -112,6 +112,8 @@ Caso utilize o Render.com para hospedar a API como serviço web, configure os co
 
 > ℹ️ O script `build` da API dispara `build:dependencies` (com `pnpm --dir ../.. -r --filter ... run build`) antes do `tsup`. Assim, os diretórios `dist` dos pacotes `@ticketz/{core,shared,storage,integrations}` são gerados antes do `node dist/server.js`, evitando erros de resolução de módulos nas etapas de deploy e runtime.
 
+> ⚠️ Se o **WhatsApp Broker** também estiver hospedado no Render, inclua/reveja as rotas permitidas para aceitar `POST /instances/:id/start` (ou o fallback `POST /instances/:id/request-pairing-code`). A API passa a utilizar esses endpoints para iniciar o pareamento e solicitar novos QR Codes; certifique-se de que o serviço do broker esteja atualizado para respondê-los.
+
 #### Variáveis de ambiente obrigatórias no Render
 
 Além das variáveis já definidas na seção de configuração (como `DATABASE_URL`, `JWT_SECRET`, `VITE_API_URL`, etc.), configure explicitamente no Render:


### PR DESCRIPTION
## Summary
- update the WhatsApp broker client to call the start/pairing endpoint instead of forcing a logout when reconnecting instances
- document the Render deployment requirement so the WhatsApp broker service allows the new start/pairing routes

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68db15d4f164833281149f49bc7055a9