### PR TITLE
feat: expand WhatsApp broker media support

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -191,17 +191,74 @@ router.post(
   param('id').isString(),
   body('to').isString(),
   body('content').isString(),
-  body('type').optional().isIn(['text', 'image', 'audio', 'video', 'document']),
+  body('type')
+    .optional()
+    .isIn(['text', 'image', 'audio', 'video', 'document', 'location', 'contact', 'template']),
   body('mediaUrl').optional().isURL(),
+  body('caption').optional().isString(),
+  body('mimeType').optional().isString(),
+  body('fileName').optional().isString(),
+  body('ptt').optional().isBoolean().toBoolean(),
+  body('location').optional().isObject(),
+  body('location.latitude').optional().isFloat({ min: -90, max: 90 }).toFloat(),
+  body('location.longitude').optional().isFloat({ min: -180, max: 180 }).toFloat(),
+  body('location.name').optional().isString(),
+  body('location.address').optional().isString(),
+  body('contact').optional().isObject(),
+  body('contact.displayName').optional().isString(),
+  body('contact.vcard').optional().isString(),
+  body('template').optional().isObject(),
+  body('template.name').optional().isString(),
+  body('template.namespace').optional().isString(),
+  body('template.language').optional().isString(),
+  body('template.languageCode').optional().isString(),
+  body('template.components').optional().isArray(),
+  body('template.variables').optional().isArray(),
+  body('template.parameters').optional().isArray(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {
     const instanceId = req.params.id;
-    const { to, content, type = 'text', mediaUrl } = req.body as {
+    const {
+      to,
+      content,
+      type = 'text',
+      mediaUrl,
+      caption,
+      mimeType,
+      fileName,
+      ptt,
+      location,
+      contact,
+      template,
+    } = req.body as {
       to: string;
       content: string;
       type?: string;
       mediaUrl?: string;
+      caption?: string;
+      mimeType?: string;
+      fileName?: string;
+      ptt?: boolean;
+      location?: {
+        latitude: number;
+        longitude: number;
+        name?: string;
+        address?: string;
+      };
+      contact?: {
+        displayName?: string;
+        vcard: string;
+      };
+      template?: {
+        name: string;
+        namespace?: string;
+        language?: string;
+        languageCode?: string;
+        components?: unknown[];
+        variables?: unknown[];
+        parameters?: unknown[];
+      };
     };
 
     try {
@@ -210,6 +267,13 @@ router.post(
         content,
         type,
         mediaUrl,
+        caption,
+        mimeType,
+        fileName,
+        ptt,
+        location,
+        contact,
+        template,
       });
 
       res.json({

--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalBrokerUrl = process.env.WHATSAPP_BROKER_URL;
+const originalBrokerKey = process.env.WHATSAPP_BROKER_API_KEY;
+
+describe('WhatsAppBrokerClient sendMessage', () => {
+  const loadClient = async () => {
+    const module = await import('./whatsapp-broker-client');
+    return module.whatsappBrokerClient;
+  };
+
+  const mockRequest = (client: unknown) =>
+    vi
+      .spyOn(client as unknown as { request: (path: string, init: unknown) => Promise<unknown> }, 'request')
+      .mockResolvedValue({ id: '123', status: 'sent' });
+
+  const restoreEnv = () => {
+    if (originalBrokerUrl === undefined) {
+      delete process.env.WHATSAPP_BROKER_URL;
+    } else {
+      process.env.WHATSAPP_BROKER_URL = originalBrokerUrl;
+    }
+
+    if (originalBrokerKey === undefined) {
+      delete process.env.WHATSAPP_BROKER_API_KEY;
+    } else {
+      process.env.WHATSAPP_BROKER_API_KEY = originalBrokerKey;
+    }
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.WHATSAPP_BROKER_URL = 'https://broker.example';
+    process.env.WHATSAPP_BROKER_API_KEY = 'secret';
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    restoreEnv();
+  });
+
+  it('sends text messages', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-1', {
+      to: '5511999999999',
+      content: 'Hello world',
+      type: 'TEXT',
+    });
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-1/send-text');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({ to: '5511999999999', message: 'Hello world' });
+  });
+
+  it('sends image messages with caption', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-2', {
+      to: '5511888888888',
+      content: 'Check this image',
+      type: 'image',
+      mediaUrl: 'https://cdn.example.com/image.jpg',
+      caption: 'Custom caption',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-2/send-image');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511888888888',
+      url: 'https://cdn.example.com/image.jpg',
+      caption: 'Custom caption',
+    });
+  });
+
+  it('sends audio messages with mimetype and ptt flag', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-3', {
+      to: '5511777777777',
+      content: 'Audio note',
+      type: 'audio',
+      mediaUrl: 'https://cdn.example.com/audio.ogg',
+      mimeType: 'audio/ogg',
+      ptt: true,
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-3/send-audio');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511777777777',
+      url: 'https://cdn.example.com/audio.ogg',
+      mimetype: 'audio/ogg',
+      ptt: true,
+    });
+  });
+
+  it('sends video messages with caption and mimetype', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-4', {
+      to: '5511666666666',
+      content: 'Video clip',
+      type: 'VIDEO',
+      mediaUrl: 'https://cdn.example.com/video.mp4',
+      caption: 'Watch this',
+      mimeType: 'video/mp4',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-4/send-video');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511666666666',
+      url: 'https://cdn.example.com/video.mp4',
+      caption: 'Watch this',
+      mimetype: 'video/mp4',
+    });
+  });
+
+  it('sends document messages with filename', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-5', {
+      to: '5511555555555',
+      content: 'See attached document',
+      type: 'document',
+      mediaUrl: 'https://cdn.example.com/report.pdf',
+      mimeType: 'application/pdf',
+      fileName: 'report.pdf',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-5/send-document');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511555555555',
+      url: 'https://cdn.example.com/report.pdf',
+      caption: 'See attached document',
+      fileName: 'report.pdf',
+      mimetype: 'application/pdf',
+    });
+  });
+
+  it('sends location messages using coordinates', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-6', {
+      to: '5511444444444',
+      content: 'Office location',
+      type: 'location',
+      location: {
+        latitude: -23.561684,
+        longitude: -46.625378,
+        name: 'Headquarters',
+        address: 'Av. Paulista, 1000',
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-6/send-location');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511444444444',
+      latitude: -23.561684,
+      longitude: -46.625378,
+      name: 'Headquarters',
+      address: 'Av. Paulista, 1000',
+    });
+  });
+
+  it('sends contact messages with vcard data', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-7', {
+      to: '5511333333333',
+      content: 'Contact info',
+      type: 'contact',
+      contact: {
+        displayName: 'Support',
+        vcard: 'BEGIN:VCARD\nFN:Support\nTEL;TYPE=CELL:+5511333333333\nEND:VCARD',
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-7/send-contact');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511333333333',
+      contact: {
+        displayName: 'Support',
+        vcard: 'BEGIN:VCARD\nFN:Support\nTEL;TYPE=CELL:+5511333333333\nEND:VCARD',
+      },
+    });
+  });
+
+  it('sends template messages with namespace and components', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-8', {
+      to: '5511222222222',
+      content: 'Template trigger',
+      type: 'template',
+      template: {
+        name: 'order_update',
+        namespace: 'ecommerce',
+        languageCode: 'pt_BR',
+        components: [
+          {
+            type: 'body',
+            parameters: [{ type: 'text', text: '12345' }],
+          },
+        ],
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-8/send-template');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511222222222',
+      namespace: 'ecommerce',
+      name: 'order_update',
+      language: 'pt_BR',
+      components: [
+        {
+          type: 'body',
+          parameters: [{ type: 'text', text: '12345' }],
+        },
+      ],
+    });
+  });
+
+  it('validates required media for audio messages', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await expect(
+      client.sendMessage('instance-9', {
+        to: '5511111111111',
+        content: 'Missing media',
+        type: 'audio',
+      } as unknown as Parameters<typeof client.sendMessage>[1])
+    ).rejects.toThrow('Media URL is required for audio messages');
+
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- map WhatsApp broker endpoints for every supported media type
- build type-specific broker payloads with captions, mimetypes, filenames, locations, contacts, and templates
- tighten WhatsApp integration request validation and add service tests covering each media payload

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68db23c0ba8083328254e3fe6bbb85f0