### PR TITLE
Ensure WhatsApp broker routes signal missing configuration

### DIFF
--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -1,0 +1,123 @@
+import express from 'express';
+import type { Request } from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { errorHandler } from '../middleware/error-handler';
+
+vi.mock('../middleware/auth', () => ({
+  requireTenant: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const originalWhatsAppEnv = {
+  url: process.env.WHATSAPP_BROKER_URL,
+  apiKey: process.env.WHATSAPP_BROKER_API_KEY,
+};
+
+const restoreWhatsAppEnv = () => {
+  if (typeof originalWhatsAppEnv.url === 'string') {
+    process.env.WHATSAPP_BROKER_URL = originalWhatsAppEnv.url;
+  } else {
+    delete process.env.WHATSAPP_BROKER_URL;
+  }
+
+  if (typeof originalWhatsAppEnv.apiKey === 'string') {
+    process.env.WHATSAPP_BROKER_API_KEY = originalWhatsAppEnv.apiKey;
+  } else {
+    delete process.env.WHATSAPP_BROKER_API_KEY;
+  }
+};
+
+afterEach(() => {
+  restoreWhatsAppEnv();
+});
+
+const startTestServer = async () => {
+  vi.resetModules();
+  delete process.env.WHATSAPP_BROKER_URL;
+  delete process.env.WHATSAPP_BROKER_API_KEY;
+
+  const { integrationsRouter } = await import('./integrations');
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as Request).user = {
+      id: 'user-1',
+      tenantId: 'tenant-123',
+      email: 'user@example.com',
+      name: 'Test User',
+      role: 'ADMIN',
+      isActive: true,
+      permissions: [],
+    };
+    next();
+  });
+  app.use('/api/integrations', integrationsRouter);
+  app.use(errorHandler);
+
+  return new Promise<{ server: Server; url: string }>((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+};
+
+const stopTestServer = (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+describe('WhatsApp integration routes when broker is not configured', () => {
+  const whatsappRoutes = [
+    {
+      name: 'start instance',
+      method: 'POST',
+      path: '/whatsapp/instances/test-instance/start',
+    },
+    {
+      name: 'stop instance',
+      method: 'POST',
+      path: '/whatsapp/instances/test-instance/stop',
+    },
+    {
+      name: 'delete instance',
+      method: 'DELETE',
+      path: '/whatsapp/instances/test-instance',
+    },
+  ] as const;
+
+  it.each(whatsappRoutes)('responds with 503 for %s', async ({ method, path }) => {
+    const { server, url } = await startTestServer();
+
+    try {
+      const response = await fetch(`${url}/api/integrations${path}`, {
+        method,
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+      });
+
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: 'WHATSAPP_NOT_CONFIGURED',
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+});

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -92,12 +92,19 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const instanceId = req.params.id;
 
-    await whatsappBrokerClient.connectInstance(instanceId);
+    try {
+      await whatsappBrokerClient.connectInstance(instanceId);
 
-    res.json({
-      success: true,
-      message: 'Instance started successfully',
-    });
+      res.json({
+        success: true,
+        message: 'Instance started successfully',
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
   })
 );
 
@@ -110,12 +117,19 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const instanceId = req.params.id;
 
-    await whatsappBrokerClient.disconnectInstance(instanceId);
+    try {
+      await whatsappBrokerClient.disconnectInstance(instanceId);
 
-    res.json({
-      success: true,
-      message: 'Instance stopped successfully',
-    });
+      res.json({
+        success: true,
+        message: 'Instance stopped successfully',
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
   })
 );
 
@@ -128,12 +142,19 @@ router.delete(
   asyncHandler(async (req: Request, res: Response) => {
     const instanceId = req.params.id;
 
-    await whatsappBrokerClient.deleteInstance(instanceId);
+    try {
+      await whatsappBrokerClient.deleteInstance(instanceId);
 
-    res.json({
-      success: true,
-      message: 'Instance deleted successfully',
-    });
+      res.json({
+        success: true,
+        message: 'Instance deleted successfully',
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
   })
 );
 

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -304,9 +304,7 @@ class WhatsAppBrokerClient {
   }
 
   async connectInstance(instanceId: string): Promise<void> {
-    if (!this.isConfigured) {
-      return;
-    }
+    this.ensureConfigured();
 
     const encodedId = encodeURIComponent(instanceId);
     const startEndpoints = [
@@ -341,9 +339,7 @@ class WhatsAppBrokerClient {
   }
 
   async disconnectInstance(instanceId: string): Promise<void> {
-    if (!this.isConfigured) {
-      return;
-    }
+    this.ensureConfigured();
 
     try {
       await this.request(`/instances/${encodeURIComponent(instanceId)}/logout`, {
@@ -358,9 +354,7 @@ class WhatsAppBrokerClient {
   }
 
   async deleteInstance(instanceId: string): Promise<void> {
-    if (!this.isConfigured) {
-      return;
-    }
+    this.ensureConfigured();
 
     try {
       await this.request(`/instances/${encodeURIComponent(instanceId)}/session/wipe`, {


### PR DESCRIPTION
## Summary
- enforce configuration checks in the WhatsApp broker client before connecting, disconnecting or deleting instances
- wrap the WhatsApp instance management routes to keep translating missing broker configuration into 503 responses
- add automated tests covering the 503 responses when broker credentials are absent

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68db23b2efb483328ec01ec5ebe6691f