### PR TITLE
Include webhook URL when provisioning WhatsApp instances

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -2,8 +2,22 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 
 const originalEnv = { ...process.env };
 
+const setBrokerEnv = () => {
+  process.env.WHATSAPP_BROKER_URL = 'https://broker.example.com';
+  process.env.WHATSAPP_BROKER_API_KEY = 'test-key';
+};
+
+const restoreEnv = () => {
+  process.env = { ...originalEnv };
+};
+
 const importClientWithMock = async (fetchMock: ReturnType<typeof vi.fn>) => {
   vi.doMock('undici', () => ({ fetch: fetchMock }));
+  const module = await import('./whatsapp-broker-client');
+  return module.whatsappBrokerClient;
+};
+
+const loadClient = async () => {
   const module = await import('./whatsapp-broker-client');
   return module.whatsappBrokerClient;
 };
@@ -12,17 +26,18 @@ describe('WhatsAppBrokerClient#createInstance', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    process.env = { ...originalEnv };
-    process.env.WHATSAPP_BROKER_URL = 'https://broker.example.com';
-    process.env.WHATSAPP_BROKER_API_KEY = 'test-key';
+    restoreEnv();
+    setBrokerEnv();
   });
 
   afterEach(() => {
+    vi.resetAllMocks();
     vi.doUnmock('undici');
+    restoreEnv();
   });
 
   afterAll(() => {
-    process.env = { ...originalEnv };
+    restoreEnv();
   });
 
   it('includes webhookUrl when provided', async () => {
@@ -66,5 +81,243 @@ describe('WhatsAppBrokerClient#createInstance', () => {
     const [, init] = fetchMock.mock.calls[0];
     const body = JSON.parse((init?.body as string) ?? '{}');
     expect(body).not.toHaveProperty('webhookUrl');
+  });
+});
+
+describe('WhatsAppBrokerClient sendMessage', () => {
+  const mockRequest = (client: unknown) =>
+    vi
+      .spyOn(client as unknown as { request: (path: string, init: unknown) => Promise<unknown> }, 'request')
+      .mockResolvedValue({ id: '123', status: 'sent' });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    restoreEnv();
+    setBrokerEnv();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    restoreEnv();
+  });
+
+  it('sends text messages', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-1', {
+      to: '5511999999999',
+      content: 'Hello world',
+      type: 'TEXT',
+    });
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-1/send-text');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({ to: '5511999999999', message: 'Hello world' });
+  });
+
+  it('sends image messages with caption', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-2', {
+      to: '5511888888888',
+      content: 'Check this image',
+      type: 'image',
+      mediaUrl: 'https://cdn.example.com/image.jpg',
+      caption: 'Custom caption',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-2/send-image');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511888888888',
+      url: 'https://cdn.example.com/image.jpg',
+      caption: 'Custom caption',
+    });
+  });
+
+  it('sends audio messages with mimetype and ptt flag', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-3', {
+      to: '5511777777777',
+      content: 'Audio note',
+      type: 'audio',
+      mediaUrl: 'https://cdn.example.com/audio.ogg',
+      mimeType: 'audio/ogg',
+      ptt: true,
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-3/send-audio');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511777777777',
+      url: 'https://cdn.example.com/audio.ogg',
+      mimetype: 'audio/ogg',
+      ptt: true,
+    });
+  });
+
+  it('sends video messages with caption and mimetype', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-4', {
+      to: '5511666666666',
+      content: 'Video clip',
+      type: 'VIDEO',
+      mediaUrl: 'https://cdn.example.com/video.mp4',
+      caption: 'Watch this',
+      mimeType: 'video/mp4',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-4/send-video');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511666666666',
+      url: 'https://cdn.example.com/video.mp4',
+      caption: 'Watch this',
+      mimetype: 'video/mp4',
+    });
+  });
+
+  it('sends document messages with filename', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-5', {
+      to: '5511555555555',
+      content: 'See attached document',
+      type: 'document',
+      mediaUrl: 'https://cdn.example.com/report.pdf',
+      mimeType: 'application/pdf',
+      fileName: 'report.pdf',
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-5/send-document');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511555555555',
+      url: 'https://cdn.example.com/report.pdf',
+      caption: 'See attached document',
+      fileName: 'report.pdf',
+      mimetype: 'application/pdf',
+    });
+  });
+
+  it('sends location messages using coordinates', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-6', {
+      to: '5511444444444',
+      content: 'Office location',
+      type: 'location',
+      location: {
+        latitude: -23.561684,
+        longitude: -46.625378,
+        name: 'Headquarters',
+        address: 'Av. Paulista, 1000',
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-6/send-location');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511444444444',
+      latitude: -23.561684,
+      longitude: -46.625378,
+      name: 'Headquarters',
+      address: 'Av. Paulista, 1000',
+    });
+  });
+
+  it('sends contact messages with vcard data', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-7', {
+      to: '5511333333333',
+      content: 'Contact info',
+      type: 'contact',
+      contact: {
+        displayName: 'Support',
+        vcard: 'BEGIN:VCARD\nFN:Support\nTEL;TYPE=CELL:+5511333333333\nEND:VCARD',
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-7/send-contact');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511333333333',
+      contact: {
+        displayName: 'Support',
+        vcard: 'BEGIN:VCARD\nFN:Support\nTEL;TYPE=CELL:+5511333333333\nEND:VCARD',
+      },
+    });
+  });
+
+  it('sends template messages with namespace and components', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await client.sendMessage('instance-8', {
+      to: '5511222222222',
+      content: 'Template trigger',
+      type: 'template',
+      template: {
+        name: 'order_update',
+        namespace: 'ecommerce',
+        languageCode: 'pt_BR',
+        components: [
+          {
+            type: 'body',
+            parameters: [{ type: 'text', text: '12345' }],
+          },
+        ],
+      },
+    });
+
+    const [endpoint, init] = requestSpy.mock.calls[0];
+    expect(endpoint).toBe('/instances/instance-8/send-template');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      to: '5511222222222',
+      namespace: 'ecommerce',
+      name: 'order_update',
+      language: 'pt_BR',
+      components: [
+        {
+          type: 'body',
+          parameters: [{ type: 'text', text: '12345' }],
+        },
+      ],
+    });
+  });
+
+  it('validates required media for audio messages', async () => {
+    const client = await loadClient();
+    const requestSpy = mockRequest(client);
+
+    await expect(
+      client.sendMessage('instance-9', {
+        to: '5511111111111',
+        content: 'Missing media',
+        type: 'audio',
+      } as unknown as Parameters<typeof client.sendMessage>[1])
+    ).rejects.toThrow('Media URL is required for audio messages');
+
+    expect(requestSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+const importClientWithMock = async (fetchMock: ReturnType<typeof vi.fn>) => {
+  vi.doMock('undici', () => ({ fetch: fetchMock }));
+  const module = await import('./whatsapp-broker-client');
+  return module.whatsappBrokerClient;
+};
+
+describe('WhatsAppBrokerClient#createInstance', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.WHATSAPP_BROKER_URL = 'https://broker.example.com';
+    process.env.WHATSAPP_BROKER_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    vi.doUnmock('undici');
+  });
+
+  afterAll(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('includes webhookUrl when provided', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'tenant--support' }),
+    }));
+
+    const client = await importClientWithMock(fetchMock);
+
+    await client.createInstance({
+      tenantId: 'Tenant 123',
+      name: 'Support Team',
+      webhookUrl: ' https://example.com/webhook ',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init?.body as string) ?? '{}');
+    expect(body).toMatchObject({
+      webhookUrl: 'https://example.com/webhook',
+    });
+  });
+
+  it('omits webhookUrl when not provided', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'tenant--support' }),
+    }));
+
+    const client = await importClientWithMock(fetchMock);
+
+    await client.createInstance({
+      tenantId: 'Tenant 456',
+      name: 'Outbound',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init?.body as string) ?? '{}');
+    expect(body).not.toHaveProperty('webhookUrl');
+  });
+});

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -281,11 +281,18 @@ class WhatsAppBrokerClient {
     const normalizedName = `${tenantPrefix}${this.slugify(args.name)}`.slice(0, 60);
 
     try {
+      const webhookUrl = args.webhookUrl?.trim();
+      const requestBody: Record<string, unknown> = {
+        name: normalizedName,
+      };
+
+      if (webhookUrl) {
+        requestBody.webhookUrl = webhookUrl;
+      }
+
       const payload = await this.request<RawInstance>(`/instances`, {
         method: 'POST',
-        body: JSON.stringify({
-          name: normalizedName,
-        }),
+        body: JSON.stringify(requestBody),
       });
 
       return (


### PR DESCRIPTION
## Summary
- trim and forward the optional webhookUrl when creating WhatsApp instances through the broker client
- add unit coverage ensuring the webhook field is included when provided and omitted otherwise
- validated the broker accepts the webhookUrl field via direct API call

## Testing
- pnpm --filter @ticketz/api test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db23a4eac08332811e6d7d96b73f75