### PR TITLE
Implement ticket service persistence for tickets API

### DIFF
--- a/apps/api/src/lib/socket-registry.ts
+++ b/apps/api/src/lib/socket-registry.ts
@@ -1,0 +1,35 @@
+import type { Server as SocketIOServer } from 'socket.io';
+
+type BroadcastEmitter = {
+  emit(event: string, payload: unknown): void;
+};
+
+export type SocketServerAdapter = Pick<SocketIOServer, 'to'>;
+
+let socketServer: SocketServerAdapter | null = null;
+
+export const registerSocketServer = (server: SocketServerAdapter | null) => {
+  socketServer = server;
+};
+
+export const getSocketServer = (): SocketServerAdapter | null => socketServer;
+
+const emitToRoom = (room: string, event: string, payload: unknown) => {
+  if (!socketServer) {
+    return;
+  }
+
+  const broadcaster = socketServer.to(room) as BroadcastEmitter;
+  if (typeof broadcaster.emit === 'function') {
+    broadcaster.emit(event, payload);
+  }
+};
+
+export const emitToTenant = (tenantId: string, event: string, payload: unknown) => {
+  emitToRoom(`tenant:${tenantId}`, event, payload);
+};
+
+export const emitToUser = (userId: string, event: string, payload: unknown) => {
+  emitToRoom(`user:${userId}`, event, payload);
+};
+

--- a/apps/api/src/routes/tickets.test.ts
+++ b/apps/api/src/routes/tickets.test.ts
@@ -1,0 +1,213 @@
+import express from 'express';
+import type { Request } from 'express';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ticketsRouter } from './tickets';
+import { errorHandler } from '../middleware/error-handler';
+import { registerSocketServer, type SocketServerAdapter } from '../lib/socket-registry';
+import { resetTicketStore } from '@ticketz/storage';
+
+vi.mock('../middleware/auth', () => ({
+  requireTenant: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+class MockSocketServer {
+  public events: Array<{ room: string; event: string; payload: unknown }> = [];
+
+  to(room: string) {
+    return {
+      emit: (event: string, payload: unknown) => {
+        this.events.push({ room, event, payload });
+      },
+    };
+  }
+}
+
+const startTestServer = async () => {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as Request).user = {
+      id: '44444444-4444-4444-4444-444444444444',
+      tenantId: 'tenant-123',
+      email: 'agent@example.com',
+      name: 'Agent Smith',
+      role: 'AGENT',
+      isActive: true,
+      permissions: ['tickets:read', 'tickets:write'],
+    };
+    next();
+  });
+  app.use('/api/tickets', ticketsRouter);
+  app.use(errorHandler);
+
+  return new Promise<{ server: Server; url: string }>((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+};
+
+const stopTestServer = (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+describe('Tickets routes', () => {
+  let mockSocket: MockSocketServer;
+
+  beforeEach(() => {
+    mockSocket = new MockSocketServer();
+    registerSocketServer(mockSocket as unknown as SocketServerAdapter);
+    resetTicketStore();
+  });
+
+  afterEach(() => {
+    registerSocketServer(null);
+  });
+
+  it('handles ticket lifecycle end-to-end', async () => {
+    const { server, url } = await startTestServer();
+
+    try {
+      const createResponse = await fetch(`${url}/api/tickets`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          contactId: '11111111-1111-1111-1111-111111111111',
+          queueId: '22222222-2222-2222-2222-222222222222',
+          subject: 'Support request',
+          channel: 'WHATSAPP',
+          priority: 'HIGH',
+          tags: ['vip'],
+          metadata: { source: 'test' },
+        }),
+      });
+
+      expect(createResponse.status).toBe(201);
+      const createdBody = await createResponse.json();
+      expect(createdBody.success).toBe(true);
+      const createdTicket = createdBody.data;
+      expect(createdTicket).toMatchObject({
+        contactId: '11111111-1111-1111-1111-111111111111',
+        queueId: '22222222-2222-2222-2222-222222222222',
+        status: 'OPEN',
+        priority: 'HIGH',
+      });
+
+      const ticketId = createdTicket.id as string;
+
+      const listResponse = await fetch(`${url}/api/tickets?limit=10`, {
+        headers: { 'x-tenant-id': 'tenant-123' },
+      });
+      expect(listResponse.status).toBe(200);
+      const listBody = await listResponse.json();
+      expect(listBody.data.items).toHaveLength(1);
+      expect(listBody.data.total).toBe(1);
+
+      const getResponse = await fetch(`${url}/api/tickets/${ticketId}`, {
+        headers: { 'x-tenant-id': 'tenant-123' },
+      });
+      expect(getResponse.status).toBe(200);
+      const getBody = await getResponse.json();
+      expect(getBody.data.id).toBe(ticketId);
+
+      const updateResponse = await fetch(`${url}/api/tickets/${ticketId}`, {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          status: 'PENDING',
+          priority: 'URGENT',
+          tags: ['vip', 'follow-up'],
+        }),
+      });
+      expect(updateResponse.status).toBe(200);
+      const updateBody = await updateResponse.json();
+      expect(updateBody.data.status).toBe('PENDING');
+      expect(updateBody.data.priority).toBe('URGENT');
+      expect(updateBody.data.tags).toContain('follow-up');
+
+      const assignResponse = await fetch(`${url}/api/tickets/${ticketId}/assign`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({ userId: '44444444-4444-4444-4444-444444444444' }),
+      });
+      expect(assignResponse.status).toBe(200);
+      const assignBody = await assignResponse.json();
+      expect(assignBody.data.userId).toBe('44444444-4444-4444-4444-444444444444');
+      expect(assignBody.data.status).toBe('ASSIGNED');
+
+      const messageResponse = await fetch(`${url}/api/tickets/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          ticketId,
+          content: 'Hello from support',
+          type: 'TEXT',
+        }),
+      });
+      expect(messageResponse.status).toBe(201);
+      const messageBody = await messageResponse.json();
+      expect(messageBody.data.ticketId).toBe(ticketId);
+      expect(messageBody.data.content).toBe('Hello from support');
+
+      const messagesListResponse = await fetch(`${url}/api/tickets/${ticketId}/messages`, {
+        headers: { 'x-tenant-id': 'tenant-123' },
+      });
+      expect(messagesListResponse.status).toBe(200);
+      const messagesListBody = await messagesListResponse.json();
+      expect(messagesListBody.data.items).toHaveLength(1);
+
+      const closeResponse = await fetch(`${url}/api/tickets/${ticketId}/close`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({ reason: 'Issue resolved' }),
+      });
+      expect(closeResponse.status).toBe(200);
+      const closeBody = await closeResponse.json();
+      expect(closeBody.data.status).toBe('CLOSED');
+      expect(closeBody.data.closeReason).toBe('Issue resolved');
+
+      const finalGetResponse = await fetch(`${url}/api/tickets/${ticketId}`, {
+        headers: { 'x-tenant-id': 'tenant-123' },
+      });
+      const finalBody = await finalGetResponse.json();
+      expect(finalBody.data.status).toBe('CLOSED');
+      expect(finalBody.data.lastMessageAt).toBeTruthy();
+
+      const emittedEvents = mockSocket.events.map((item) => item.event);
+      expect(emittedEvents).toContain('ticket.created');
+      expect(emittedEvents).toContain('ticket.updated');
+      expect(emittedEvents).toContain('ticket.assigned');
+      expect(emittedEvents).toContain('ticket.message');
+      expect(emittedEvents).toContain('ticket.closed');
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+});
+

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -18,6 +18,7 @@ import { webhooksRouter } from './routes/webhooks';
 import { integrationsRouter } from './routes/integrations';
 import { leadEngineRouter } from './routes/lead-engine';
 import { logger } from './config/logger';
+import { registerSocketServer } from './lib/socket-registry';
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -86,6 +87,8 @@ const io = new SocketIOServer(server, {
         credentials: true,
       },
 });
+
+registerSocketServer(io);
 
 // Configurações básicas
 const PORT = process.env.PORT || 4000;

--- a/apps/api/src/services/ticket-service.ts
+++ b/apps/api/src/services/ticket-service.ts
@@ -1,0 +1,143 @@
+import {
+  ConflictError,
+  CreateTicketDTO,
+  Message,
+  Pagination,
+  PaginatedResult,
+  SendMessageDTO,
+  Ticket,
+  TicketFilters,
+  UpdateTicketDTO,
+  NotFoundError,
+} from '@ticketz/core';
+import {
+  assignTicket as storageAssignTicket,
+  closeTicket as storageCloseTicket,
+  createMessage as storageCreateMessage,
+  createTicket as storageCreateTicket,
+  findTicketById as storageFindTicketById,
+  findTicketsByContact,
+  listMessages as storageListMessages,
+  listTickets as storageListTickets,
+  updateTicket as storageUpdateTicket,
+} from '@ticketz/storage';
+import { emitToTenant, emitToUser } from '../lib/socket-registry';
+
+const OPEN_STATUSES = new Set(['OPEN', 'PENDING', 'ASSIGNED']);
+
+const emitTicketEvent = (tenantId: string, event: string, payload: unknown, userId?: string | null) => {
+  emitToTenant(tenantId, event, payload);
+  if (userId) {
+    emitToUser(userId, event, payload);
+  }
+};
+
+export const listTickets = async (
+  tenantId: string,
+  filters: TicketFilters,
+  pagination: Pagination
+): Promise<PaginatedResult<Ticket>> => {
+  return storageListTickets(tenantId, filters, pagination);
+};
+
+export const getTicketById = async (tenantId: string, ticketId: string): Promise<Ticket> => {
+  const ticket = await storageFindTicketById(tenantId, ticketId);
+  if (!ticket) {
+    throw new NotFoundError('Ticket', ticketId);
+  }
+  return ticket;
+};
+
+export const createTicket = async (input: CreateTicketDTO): Promise<Ticket> => {
+  const existingTickets = await findTicketsByContact(input.tenantId, input.contactId);
+  const openTicket = existingTickets.find((ticket) => OPEN_STATUSES.has(ticket.status));
+
+  if (openTicket) {
+    throw new ConflictError('Contact already has an open ticket', {
+      existingTicketId: openTicket.id,
+    });
+  }
+
+  const ticket = await storageCreateTicket(input);
+  emitTicketEvent(input.tenantId, 'ticket.created', ticket, ticket.userId ?? null);
+  return ticket;
+};
+
+export const updateTicket = async (
+  tenantId: string,
+  ticketId: string,
+  input: UpdateTicketDTO
+): Promise<Ticket> => {
+  const updated = await storageUpdateTicket(tenantId, ticketId, input);
+  if (!updated) {
+    throw new NotFoundError('Ticket', ticketId);
+  }
+
+  emitTicketEvent(tenantId, 'ticket.updated', updated, updated.userId ?? null);
+  return updated;
+};
+
+export const assignTicket = async (
+  tenantId: string,
+  ticketId: string,
+  userId: string
+): Promise<Ticket> => {
+  const updated = await storageAssignTicket(tenantId, ticketId, userId);
+  if (!updated) {
+    throw new NotFoundError('Ticket', ticketId);
+  }
+
+  emitTicketEvent(tenantId, 'ticket.assigned', updated, userId);
+  return updated;
+};
+
+export const closeTicket = async (
+  tenantId: string,
+  ticketId: string,
+  reason: string | undefined,
+  userId: string | undefined
+): Promise<Ticket> => {
+  const updated = await storageCloseTicket(tenantId, ticketId, reason, userId);
+  if (!updated) {
+    throw new NotFoundError('Ticket', ticketId);
+  }
+
+  emitTicketEvent(tenantId, 'ticket.closed', updated, userId ?? updated.userId ?? null);
+  return updated;
+};
+
+export const listMessages = async (
+  tenantId: string,
+  ticketId: string,
+  pagination: Pagination
+): Promise<PaginatedResult<Message>> => {
+  await getTicketById(tenantId, ticketId);
+  return storageListMessages(tenantId, { ticketId }, pagination);
+};
+
+export const sendMessage = async (
+  tenantId: string,
+  userId: string | undefined,
+  input: SendMessageDTO
+): Promise<Message> => {
+  const message = await storageCreateMessage(tenantId, input.ticketId, {
+    ...input,
+    direction: userId ? 'OUTBOUND' : 'INBOUND',
+    userId,
+    status: 'SENT',
+  });
+
+  if (!message) {
+    throw new NotFoundError('Ticket', input.ticketId);
+  }
+
+  emitToTenant(tenantId, 'ticket.message', message);
+
+  const ticket = await storageFindTicketById(tenantId, input.ticketId);
+  if (ticket) {
+    emitTicketEvent(tenantId, 'ticket.updated', ticket, ticket.userId ?? null);
+  }
+
+  return message;
+};
+

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -20,3 +20,16 @@ export {
   listCampaigns,
   resetCampaignStore,
 } from './repositories/campaign-repository';
+
+export {
+  resetTicketStore,
+  findTicketById,
+  findTicketsByContact,
+  createTicket,
+  updateTicket,
+  assignTicket,
+  closeTicket,
+  listTickets,
+  createMessage,
+  listMessages,
+} from './repositories/ticket-repository';

--- a/packages/storage/src/repositories/ticket-repository.ts
+++ b/packages/storage/src/repositories/ticket-repository.ts
@@ -1,0 +1,446 @@
+import { randomUUID } from 'node:crypto';
+import {
+  CreateTicketDTO,
+  Message,
+  MessageFilters,
+  Pagination,
+  PaginatedResult,
+  SendMessageDTO,
+  Ticket,
+  TicketFilters,
+  TicketStatus,
+  UpdateTicketDTO,
+} from '@ticketz/core';
+
+type TicketRecord = Ticket & {
+  lastMessagePreview?: string;
+};
+
+type MessageRecord = Message;
+
+const ticketsByTenant = new Map<string, Map<string, TicketRecord>>();
+const messagesByTenant = new Map<string, Map<string, MessageRecord>>();
+
+const defaultPagination = (pagination: Pagination): Required<Pagination> => ({
+  page: pagination.page ?? 1,
+  limit: pagination.limit ?? 20,
+  sortBy: pagination.sortBy,
+  sortOrder: pagination.sortOrder ?? 'desc',
+});
+
+const getTicketBucket = (tenantId: string) => {
+  let bucket = ticketsByTenant.get(tenantId);
+  if (!bucket) {
+    bucket = new Map<string, TicketRecord>();
+    ticketsByTenant.set(tenantId, bucket);
+  }
+  return bucket;
+};
+
+const getMessageBucket = (tenantId: string) => {
+  let bucket = messagesByTenant.get(tenantId);
+  if (!bucket) {
+    bucket = new Map<string, MessageRecord>();
+    messagesByTenant.set(tenantId, bucket);
+  }
+  return bucket;
+};
+
+const toTicket = (record: TicketRecord): Ticket => ({
+  ...record,
+  tags: [...record.tags],
+  metadata: { ...record.metadata },
+});
+
+const toMessage = (record: MessageRecord): Message => ({
+  ...record,
+  metadata: { ...record.metadata },
+});
+
+const matchesTicketFilters = (ticket: TicketRecord, filters: TicketFilters): boolean => {
+  if (filters.status && filters.status.length > 0 && !filters.status.includes(ticket.status)) {
+    return false;
+  }
+
+  if (filters.priority && filters.priority.length > 0 && !filters.priority.includes(ticket.priority)) {
+    return false;
+  }
+
+  if (filters.queueId && filters.queueId.length > 0 && !filters.queueId.includes(ticket.queueId)) {
+    return false;
+  }
+
+  if (filters.userId && filters.userId.length > 0 && (!ticket.userId || !filters.userId.includes(ticket.userId))) {
+    return false;
+  }
+
+  if (filters.channel && filters.channel.length > 0 && !filters.channel.includes(ticket.channel)) {
+    return false;
+  }
+
+  if (filters.tags && filters.tags.length > 0) {
+    const hasTag = ticket.tags.some((tag) => filters.tags?.includes(tag));
+    if (!hasTag) {
+      return false;
+    }
+  }
+
+  if (filters.dateFrom && ticket.createdAt < filters.dateFrom) {
+    return false;
+  }
+
+  if (filters.dateTo && ticket.createdAt > filters.dateTo) {
+    return false;
+  }
+
+  if (filters.search && filters.search.trim().length > 0) {
+    const normalized = filters.search.trim().toLowerCase();
+    const searchableValues = [
+      ticket.id,
+      ticket.subject ?? '',
+      ticket.contactId,
+      ticket.queueId,
+      ticket.userId ?? '',
+      ticket.tags.join(' '),
+      ticket.metadata?.summary ? String(ticket.metadata.summary) : '',
+    ];
+
+    const hasMatch = searchableValues.some((value) => value.toLowerCase().includes(normalized));
+    if (!hasMatch) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const matchesMessageFilters = (message: MessageRecord, filters: MessageFilters): boolean => {
+  if (filters.ticketId && message.ticketId !== filters.ticketId) {
+    return false;
+  }
+
+  if (filters.contactId && message.contactId !== filters.contactId) {
+    return false;
+  }
+
+  if (filters.userId && message.userId !== filters.userId) {
+    return false;
+  }
+
+  if (filters.direction && filters.direction.length > 0 && !filters.direction.includes(message.direction)) {
+    return false;
+  }
+
+  if (filters.type && filters.type.length > 0 && !filters.type.includes(message.type)) {
+    return false;
+  }
+
+  if (filters.status && filters.status.length > 0 && !filters.status.includes(message.status)) {
+    return false;
+  }
+
+  if (filters.dateFrom && message.createdAt < filters.dateFrom) {
+    return false;
+  }
+
+  if (filters.dateTo && message.createdAt > filters.dateTo) {
+    return false;
+  }
+
+  if (filters.search && filters.search.trim().length > 0) {
+    const normalized = filters.search.trim().toLowerCase();
+    const searchableValues = [message.id, message.content, message.metadata?.summary ? String(message.metadata.summary) : ''];
+    const hasMatch = searchableValues.some((value) => value.toLowerCase().includes(normalized));
+    if (!hasMatch) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const sortTickets = (tickets: TicketRecord[], sortBy?: string, sortOrder: 'asc' | 'desc' = 'desc') => {
+  const direction = sortOrder === 'asc' ? 1 : -1;
+  const allowedFields = new Set(['createdAt', 'updatedAt', 'lastMessageAt', 'priority']);
+  const field = allowedFields.has(sortBy ?? '') ? (sortBy as keyof TicketRecord) : 'createdAt';
+
+  return tickets.sort((a, b) => {
+    const valueA = a[field];
+    const valueB = b[field];
+
+    if (valueA === valueB) {
+      return 0;
+    }
+
+    if (valueA === undefined || valueA === null) {
+      return 1;
+    }
+
+    if (valueB === undefined || valueB === null) {
+      return -1;
+    }
+
+    if (valueA instanceof Date && valueB instanceof Date) {
+      return valueA.getTime() > valueB.getTime() ? direction : -direction;
+    }
+
+    if (typeof valueA === 'string' && typeof valueB === 'string') {
+      return valueA.localeCompare(valueB) * direction;
+    }
+
+    if (typeof valueA === 'number' && typeof valueB === 'number') {
+      return valueA > valueB ? direction : -direction;
+    }
+
+    return 0;
+  });
+};
+
+const sortMessages = (messages: MessageRecord[], sortOrder: 'asc' | 'desc') => {
+  const direction = sortOrder === 'asc' ? 1 : -1;
+  return messages.sort((a, b) => (a.createdAt > b.createdAt ? direction : -direction));
+};
+
+export const resetTicketStore = () => {
+  ticketsByTenant.clear();
+  messagesByTenant.clear();
+};
+
+export const findTicketById = async (tenantId: string, ticketId: string): Promise<Ticket | null> => {
+  const bucket = getTicketBucket(tenantId);
+  const record = bucket.get(ticketId);
+  return record ? toTicket(record) : null;
+};
+
+export const findTicketsByContact = async (tenantId: string, contactId: string): Promise<Ticket[]> => {
+  const bucket = getTicketBucket(tenantId);
+  return Array.from(bucket.values())
+    .filter((ticket) => ticket.contactId === contactId)
+    .map(toTicket);
+};
+
+export const createTicket = async (input: CreateTicketDTO): Promise<Ticket> => {
+  const bucket = getTicketBucket(input.tenantId);
+  const now = new Date();
+  const record: TicketRecord = {
+    id: randomUUID(),
+    tenantId: input.tenantId,
+    contactId: input.contactId,
+    queueId: input.queueId,
+    userId: undefined,
+    status: 'OPEN',
+    priority: input.priority ?? 'NORMAL',
+    subject: input.subject,
+    channel: input.channel,
+    lastMessageAt: undefined,
+    lastMessagePreview: undefined,
+    tags: [...(input.tags ?? [])],
+    metadata: { ...(input.metadata ?? {}) },
+    closedAt: undefined,
+    closedBy: undefined,
+    closeReason: undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  bucket.set(record.id, record);
+  return toTicket(record);
+};
+
+export const updateTicket = async (
+  tenantId: string,
+  ticketId: string,
+  input: UpdateTicketDTO & {
+    lastMessageAt?: Date;
+    lastMessagePreview?: string;
+    closedAt?: Date | null;
+    closedBy?: string | null;
+  }
+): Promise<Ticket | null> => {
+  const bucket = getTicketBucket(tenantId);
+  const record = bucket.get(ticketId);
+  if (!record) {
+    return null;
+  }
+
+  if (typeof input.status === 'string') {
+    record.status = input.status as TicketStatus;
+  }
+
+  if (typeof input.priority === 'string') {
+    record.priority = input.priority;
+  }
+
+  if (typeof input.subject === 'string' || input.subject === undefined) {
+    record.subject = input.subject ?? record.subject;
+  }
+
+  if (typeof input.userId === 'string' || input.userId === null) {
+    record.userId = input.userId ?? undefined;
+  }
+
+  if (typeof input.queueId === 'string') {
+    record.queueId = input.queueId;
+  }
+
+  if (Array.isArray(input.tags)) {
+    record.tags = [...input.tags];
+  }
+
+  if (typeof input.metadata === 'object' && input.metadata !== null) {
+    record.metadata = { ...input.metadata };
+  }
+
+  if (typeof input.closeReason === 'string' || input.closeReason === null) {
+    record.closeReason = input.closeReason ?? undefined;
+  }
+
+  if (input.lastMessageAt) {
+    record.lastMessageAt = input.lastMessageAt;
+  }
+
+  if (input.lastMessagePreview) {
+    record.lastMessagePreview = input.lastMessagePreview;
+  }
+
+  if (input.closedAt !== undefined) {
+    record.closedAt = input.closedAt ?? undefined;
+  }
+
+  if (input.closedBy !== undefined) {
+    record.closedBy = input.closedBy ?? undefined;
+  }
+
+  record.updatedAt = new Date();
+
+  return toTicket(record);
+};
+
+export const assignTicket = async (
+  tenantId: string,
+  ticketId: string,
+  userId: string
+): Promise<Ticket | null> => {
+  const updated = await updateTicket(tenantId, ticketId, { userId, status: 'ASSIGNED' });
+  return updated;
+};
+
+export const closeTicket = async (
+  tenantId: string,
+  ticketId: string,
+  reason: string | undefined,
+  userId: string | undefined
+): Promise<Ticket | null> => {
+  const now = new Date();
+  const updated = await updateTicket(tenantId, ticketId, {
+    status: 'CLOSED',
+    closeReason: reason,
+    closedAt: now,
+    closedBy: userId ?? null,
+  });
+  return updated;
+};
+
+export const listTickets = async (
+  tenantId: string,
+  filters: TicketFilters,
+  pagination: Pagination
+): Promise<PaginatedResult<Ticket>> => {
+  const bucket = getTicketBucket(tenantId);
+  const normalizedPagination = defaultPagination(pagination);
+  const filtered = Array.from(bucket.values()).filter((ticket) => matchesTicketFilters(ticket, filters));
+  const sorted = sortTickets(filtered, normalizedPagination.sortBy, normalizedPagination.sortOrder);
+
+  const start = (normalizedPagination.page - 1) * normalizedPagination.limit;
+  const end = start + normalizedPagination.limit;
+  const paginated = sorted.slice(start, end);
+  const total = filtered.length;
+  const totalPages = total === 0 ? 0 : Math.ceil(total / normalizedPagination.limit);
+
+  return {
+    items: paginated.map(toTicket),
+    total,
+    page: normalizedPagination.page,
+    limit: normalizedPagination.limit,
+    totalPages,
+    hasNext: normalizedPagination.page < totalPages,
+    hasPrev: normalizedPagination.page > 1 && total > 0,
+  };
+};
+
+export const createMessage = async (
+  tenantId: string,
+  ticketId: string,
+  input: SendMessageDTO & {
+    userId?: string;
+    direction: Message['direction'];
+    status?: Message['status'];
+  }
+): Promise<Message | null> => {
+  const ticketsBucket = getTicketBucket(tenantId);
+  const ticket = ticketsBucket.get(ticketId);
+
+  if (!ticket) {
+    return null;
+  }
+
+  const bucket = getMessageBucket(tenantId);
+  const now = new Date();
+  const record: MessageRecord = {
+    id: randomUUID(),
+    tenantId,
+    ticketId,
+    contactId: ticket.contactId,
+    userId: input.userId,
+    direction: input.direction,
+    type: input.type ?? 'TEXT',
+    content: input.content,
+    mediaUrl: input.mediaUrl,
+    mediaType: undefined,
+    mediaSize: undefined,
+    status: input.status ?? 'SENT',
+    externalId: undefined,
+    quotedMessageId: input.quotedMessageId,
+    metadata: { ...(input.metadata ?? {}) },
+    deliveredAt: undefined,
+    readAt: undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  bucket.set(record.id, record);
+
+  ticket.lastMessageAt = now;
+  ticket.lastMessagePreview = record.content.slice(0, 280);
+  ticket.updatedAt = now;
+
+  return toMessage(record);
+};
+
+export const listMessages = async (
+  tenantId: string,
+  filters: MessageFilters,
+  pagination: Pagination
+): Promise<PaginatedResult<Message>> => {
+  const bucket = getMessageBucket(tenantId);
+  const normalizedPagination = defaultPagination(pagination);
+  const filtered = Array.from(bucket.values()).filter((message) => matchesMessageFilters(message, filters));
+  const sorted = sortMessages(filtered, normalizedPagination.sortOrder);
+
+  const start = (normalizedPagination.page - 1) * normalizedPagination.limit;
+  const end = start + normalizedPagination.limit;
+  const paginated = sorted.slice(start, end);
+  const total = filtered.length;
+  const totalPages = total === 0 ? 0 : Math.ceil(total / normalizedPagination.limit);
+
+  return {
+    items: paginated.map(toMessage),
+    total,
+    page: normalizedPagination.page,
+    limit: normalizedPagination.limit,
+    totalPages,
+    hasNext: normalizedPagination.page < totalPages,
+    hasPrev: normalizedPagination.page > 1 && total > 0,
+  };
+};
+


### PR DESCRIPTION
## Summary
- add in-memory ticket repository to the storage package with filtering, pagination, and messaging helpers
- introduce a ticket service and socket registry in the API, wiring ticket routes to real data and websocket events
- cover the ticket lifecycle with a new integration test ensuring creation, updates, assignment, messaging, and closure all work together

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68db2b21e75c8332b30ff4a209ae0812