### PR TITLE
Fix default pagination typing

### DIFF
--- a/packages/storage/src/repositories/ticket-repository.ts
+++ b/packages/storage/src/repositories/ticket-repository.ts
@@ -21,7 +21,9 @@ type MessageRecord = Message;
 const ticketsByTenant = new Map<string, Map<string, TicketRecord>>();
 const messagesByTenant = new Map<string, Map<string, MessageRecord>>();
 
-const defaultPagination = (pagination: Pagination): Required<Pagination> => ({
+const defaultPagination = (
+  pagination: Pagination
+): Pagination & Required<Pick<Pagination, 'page' | 'limit' | 'sortOrder'>> => ({
   page: pagination.page ?? 1,
   limit: pagination.limit ?? 20,
   sortBy: pagination.sortBy,


### PR DESCRIPTION
## Summary
- update `defaultPagination` to require only page, limit, and sortOrder while keeping `sortBy` optional

## Testing
- pnpm -r build *(fails: apps/web build: `vite build` exits with status 1)*
- pnpm --filter storage build *(fails: DTS build cannot compile because TypeScript reports TS6059 about files outside `rootDir` when resolving `@ticketz/core`)*

------
https://chatgpt.com/codex/tasks/task_e_68db3513dc688332bc75dc227851ed3f