### PR TITLE
chore(storage): consume core declarations

### DIFF
--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": false
-  }
+    "composite": false,
+    "paths": {
+      "@ticketz/core": ["../core/dist/index.d.ts"],
+      "@ticketz/core/*": ["../core/dist/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- override the storage DTS build config to resolve @ticketz/core imports from the built declaration output
- keep the DTS build focused on local sources by explicitly listing include/exclude globs

## Testing
- `pnpm --filter @ticketz/core build`
- `pnpm --filter @ticketz/storage build` *(fails: existing TS type errors in storage declarations)*
- `pnpm -r build` *(fails: apps/web vite build exits 1 before storage)*

------
https://chatgpt.com/codex/tasks/task_e_68db35286c008332b9771f767d73710b