### PR TITLE
feat(web): improve bundle splitting

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,13 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import Layout from './components/Layout.jsx';
-import Dashboard from './components/Dashboard.jsx';
 import UnderConstruction from './components/UnderConstruction.jsx';
-import AgreementGrid from './components/AgreementGrid.jsx';
-import WhatsAppConnect from './components/WhatsAppConnect.jsx';
-import LeadInbox from './components/LeadInbox.jsx';
-import Reports from './components/Reports.jsx';
-import Settings from './components/Settings.jsx';
 import './App.css';
+
+const Dashboard = lazy(() => import('./components/Dashboard.jsx'));
+const AgreementGrid = lazy(() => import('./components/AgreementGrid.jsx'));
+const WhatsAppConnect = lazy(() => import('./components/WhatsAppConnect.jsx'));
+const LeadInbox = lazy(() => import('./components/LeadInbox.jsx'));
+const Reports = lazy(() => import('./components/Reports.jsx'));
+const Settings = lazy(() => import('./components/Settings.jsx'));
 
 const STORAGE_KEY = 'leadengine_onboarding_v1';
 
@@ -17,6 +18,12 @@ const journeyStages = [
   { id: 'whatsapp', label: 'WhatsApp' },
   { id: 'inbox', label: 'Inbox' },
 ];
+
+const PageFallback = () => (
+  <div className="flex min-h-[200px] items-center justify-center text-muted-foreground">
+    Carregando módulo...
+  </div>
+);
 
 function App() {
   const [currentPage, setCurrentPage] = useState('dashboard');
@@ -153,7 +160,9 @@ function App() {
         activeCampaign,
       }}
     >
-      {renderPage()}
+      <Suspense fallback={<PageFallback />}>
+        {renderPage()}
+      </Suspense>
     </Layout>
   );
 }

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -14,6 +14,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  optimizeDeps: {
+    include: ['@tanstack/react-query', '@tanstack/query-core', 'recharts'],
+  },
   server: {
     port: 5173,
     host: true,
@@ -26,11 +29,47 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: false,
     minify: 'esbuild',
+    chunkSizeWarningLimit: 800,
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          ui: ['@radix-ui/react-dialog', '@radix-ui/react-dropdown-menu'],
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return undefined;
+          }
+
+          if (id.includes('/react@') || id.includes('/react/')) {
+            return 'vendor-react-core';
+          }
+
+          if (id.includes('react-dom') || id.includes('scheduler')) {
+            return 'vendor-react-dom';
+          }
+
+          if (id.includes('react-router-dom')) {
+            return 'vendor-react-router';
+          }
+
+          if (id.includes('@tanstack/react-query')) {
+            return 'vendor-react-query';
+          }
+
+          if (id.includes('recharts')) {
+            return 'vendor-recharts';
+          }
+
+          if (id.includes('@radix-ui')) {
+            return 'vendor-radix';
+          }
+
+          if (id.includes('framer-motion')) {
+            return 'vendor-framer-motion';
+          }
+
+          if (id.includes('lucide-react')) {
+            return 'vendor-icons';
+          }
+
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Summary
- lazy load dashboard flows in the web app so Vite can split heavy pages automatically
- refine Vite manual chunk configuration to isolate large vendor bundles and prebundle React Query/Recharts
- raise the chunk warning limit to accommodate React DOM while keeping build output warnings clean

## Testing
- pnpm --filter web run build

------
https://chatgpt.com/codex/tasks/task_e_68db353c9294833280b831f0fad38c9f