### PR TITLE
Document WhatsApp broker API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ DATABASE_URL="postgresql://user:password@localhost:5432/ticketz"
 
 # WhatsApp
 WHATSAPP_SESSIONS_PATH=./sessions
+WHATSAPP_BROKER_URL=https://baileys-acessuswpp.onrender.com
+WHATSAPP_BROKER_API_KEY=troque-por-uma-chave-forte
 
 # URA
 URA_API_URL=https://api.ura-provider.com
@@ -111,6 +113,8 @@ URA_API_KEY=your-ura-api-key
 # Logs
 LOG_LEVEL=info
 ```
+
+> **Importante:** o valor de `WHATSAPP_BROKER_API_KEY` deve coincidir com a variável `API_KEY` configurada na Render para o serviço `baileys-acessuswpp`. Esse segredo precisa ser enviado em todas as chamadas para o broker através do cabeçalho `x-api-key`, inclusive por quaisquer serviços que consumam o `WEBHOOK_URL` configurado na instância.
 
 > **Dica:** Defina `CORS_ALLOWED_ORIGINS` com uma lista de domínios adicionais (separados por vírgula) quando precisar liberar múltiplos frontends hospedados simultaneamente. O valor de `FRONTEND_URL` continua sendo utilizado como origem principal.
 > **Demo:** `AUTH_ALLOW_JWT_FALLBACK` permite aceitar tokens JWT válidos mesmo quando o usuário não existe no banco (útil em ambientes de demonstração). Defina como `false` em produção para exigir usuários persistidos.
@@ -179,6 +183,8 @@ cd apps/web && npm run build
 - ✅ Envio de mensagens e mídias
 - ✅ Webhooks para recebimento
 - ✅ Status de conexão em tempo real
+
+> **Segurança:** defina `WHATSAPP_BROKER_API_KEY` no backend e configure o serviço `baileys-acessuswpp` na Render com a variável `API_KEY` correspondente. Toda chamada ao broker (incluindo webhooks e testes manuais) deve enviar o cabeçalho `x-api-key` com esse valor.
 
 ### ☎️ Sistema URA
 - ✅ Fluxos de atendimento

--- a/apps/baileys-acessuswpp/render.yaml
+++ b/apps/baileys-acessuswpp/render.yaml
@@ -1,0 +1,19 @@
+# Render configuration for the baileys-acessuswpp broker.
+#
+# The service itself is managed through the Render dashboard, but we
+# keep the required environment variables versioned so secrets are not
+# accidentally removed when the infrastructure is reapplied.
+services:
+  - type: web
+    name: baileys-acessuswpp
+    envVars:
+      - key: API_KEY
+        sync: false
+        comment: >-
+          Shared secret used by LeadEngine clients (exported as
+          WHATSAPP_BROKER_API_KEY) to authenticate via the x-api-key header.
+      - key: WEBHOOK_URL
+        sync: false
+        comment: >-
+          HTTPS endpoint that receives broker events. Ensure whatever
+          service owns this URL enforces the same x-api-key secret.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -47,6 +47,8 @@ RATE_LIMIT_MAX_REQUESTS=100 # opcional (padrão: 100 requisições)
 
 > Em produção substitua os defaults por credenciais reais e, se necessário, habilite SSL do banco (`DATABASE_SSL=true`).
 
+> **Importante:** o serviço `baileys-acessuswpp` na Render deve expor a variável `API_KEY` com o mesmo valor configurado aqui em `WHATSAPP_BROKER_API_KEY`. Toda integração (incluindo webhooks configurados via `WEBHOOK_URL`) precisa enviar esse segredo no cabeçalho `x-api-key` ao chamar o broker.
+
 As variáveis `RATE_LIMIT_WINDOW_MS` e `RATE_LIMIT_MAX_REQUESTS` permitem ajustar a janela e o número máximo de requisições por IP aplicados pelo middleware de rate limiting da API. Valores não numéricos ou inválidos são ignorados e os padrões (15 minutos / 100 requisições) são utilizados. Use `CORS_ALLOWED_ORIGINS` para informar uma lista (separada por vírgula) de domínios extras autorizados a consumir a API via navegador; quando ausente, a aplicação libera apenas os domínios padrão (`FRONTEND_URL`, ambientes locais e os domínios históricos do projeto).
 
 ## 4. Subindo os serviços


### PR DESCRIPTION
## Summary
- add a Render configuration stub for the baileys-acessuswpp broker with an explicit API_KEY secret requirement
- document the WhatsApp broker x-api-key header requirement and environment variables in the README and Docker guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db42633cbc83328502bdf85ae32e10