### PR TITLE
chore: upgrade runtime images to Node 20

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -109,6 +109,7 @@ Caso utilize o Render.com para hospedar a API como serviço web, configure os co
 | --- | --- |
 | Build Command | `pnpm --filter @ticketz/api run build` |
 | Start Command | `pnpm --filter @ticketz/api start` |
+| Node version | Defina `NODE_VERSION=20` nas variáveis de ambiente ou no blueprint |
 
 > ℹ️ O script `build` da API dispara `build:dependencies` (com `pnpm --dir ../.. -r --filter ... run build`) antes do `tsup`. Assim, os diretórios `dist` dos pacotes `@ticketz/{core,shared,storage,integrations}` são gerados antes do `node dist/server.js`, evitando erros de resolução de módulos nas etapas de deploy e runtime.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ticketz-leadengine/
 ### Stack Tecnológica
 
 #### Backend
-- **Node.js 18+** com TypeScript
+- **Node.js 20+** com TypeScript
 - **Express.js** para API REST
 - **Socket.IO** para tempo real
 - **Prisma** para ORM (preparado)
@@ -61,7 +61,7 @@ ticketz-leadengine/
 ## 🚀 Instalação e Configuração
 
 ### Pré-requisitos
-- Node.js 18+
+- Node.js 20+
 - pnpm (recomendado) ou npm
 - Git
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 
 # Stage 1: Base com dependências do sistema
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 # Instalar dependências do sistema necessárias
 RUN apk add --no-cache \

--- a/apps/api/Dockerfile-old
+++ b/apps/api/Dockerfile-old
@@ -1,5 +1,5 @@
 # Stage 1: install dependencies and build everything
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN pnpm --filter ./apps/api --prod deploy /app/deploy
 WORKDIR /app/deploy
 
 # Stage 3: runtime image
-FROM node:18-alpine AS runtime
+FROM node:20-alpine AS runtime
 
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 
 # Stage 1: Base com Node.js
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 # Instalar dependências do sistema
 RUN apk add --no-cache \

--- a/apps/web/Dockerfile-old
+++ b/apps/web/Dockerfile-old
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vitest": "^1.1.0"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
   "packageManager": "pnpm@8.15.0",


### PR DESCRIPTION
## Summary
- bump the workspace Node requirement to 20 and document the Render configuration change
- update the API and web Dockerfiles (including legacy variants) to build from the Node 20 alpine images
- refresh the README prerequisites to call out the new Node 20 baseline

## Testing
- pnpm install
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68db4275e5d08332b1cce14d8080ddfc