### PR TITLE
Ensure API uses Render-provided port in production

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -91,8 +91,15 @@ const io = new SocketIOServer(server, {
 registerSocketServer(io);
 
 // Configurações básicas
-const PORT = process.env.PORT || 4000;
 const NODE_ENV = process.env.NODE_ENV || 'development';
+const fallbackPort = NODE_ENV !== 'production' ? '4000' : undefined;
+const resolvedPort = process.env.PORT ?? fallbackPort;
+
+if (!resolvedPort) {
+  throw new Error('PORT environment variable must be defined in production environments.');
+}
+
+const PORT = Number(resolvedPort);
 
 // Rate limit configuration
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;


### PR DESCRIPTION
## Summary
- ensure the API server only falls back to the local development port when not running in production
- fail fast in production if the Render-provided PORT variable is missing

## Testing
- pnpm --filter @ticketz/api type-check *(fails: existing workspace build artifacts and Prisma types are required prior to running type-check)*

------
https://chatgpt.com/codex/tasks/task_e_68db4654408083329314df4e96e4dad6