### PR TITLE
Fix Render deployment by forcing npm libsignal and cleaning API scripts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,19 +4,10 @@
   "description": "API REST para o sistema Ticketz-LeadEngine",
   "main": "dist/server.js",
   "scripts": {
-
-    "build:dependencies": "pnpm --dir ../.. -r --filter @ticketz/core --filter @ticketz/shared --filter @ticketz/storage --filter @ticketz/integrations run build",
+    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/shared --filter @ticketz/storage --filter @ticketz/integrations build",
     "build": "pnpm run build:dependencies && pnpm run db:generate && tsup",
     "dev": "tsx watch src/server.ts",
     "prestart": "pnpm run build:dependencies && pnpm run db:generate",
-    "dev": "tsx watch src/server.ts",
-    "prestart": "pnpm run build:dependencies && pnpm run db:generate",
-
-    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/shared --filter @ticketz/storage --filter @ticketz/integrations build",
-    "build": "pnpm run build:dependencies && prisma generate --schema=../../prisma/schema.prisma && tsup",
-    "dev": "tsx watch src/server.ts",
-    "prestart": "pnpm run build:dependencies",
-
     "start": "node dist/server.js",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/baileys-acessuswpp/package.json
+++ b/baileys-acessuswpp/package.json
@@ -12,6 +12,6 @@
     "libsignal": "1.0.7"
   },
   "overrides": {
-    "libsignal": "1.0.7"
+    "libsignal": "npm:libsignal@1.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "pnpm": ">=8.0.0"
   },
   "packageManager": "pnpm@8.15.0",
+  "pnpm": {
+    "overrides": {
+      "libsignal": "npm:libsignal@1.0.7"
+    }
+  },
   "keywords": [
     "tickets",
     "leads",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  libsignal: npm:libsignal@1.0.7
+
 importers:
 
   .:
@@ -3069,8 +3072,8 @@ packages:
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
     dev: true
 
-  /@types/long@4.0.2:
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+  /@types/long@3.0.32:
+    resolution: {integrity: sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==}
     dev: false
 
   /@types/mime@1.3.5:
@@ -3087,14 +3090,14 @@ packages:
       '@types/express': 4.17.23
     dev: true
 
-  /@types/node@10.17.60:
-    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
-    dev: false
-
   /@types/node@20.19.18:
     resolution: {integrity: sha512-KeYVbfnbsBCyKG8e3gmUqAfyZNcoj/qpEbHRkQkfZdKOBrU7QQ+BsTdfqLSWX9/m1ytYreMhpKvp+EZi3UFYAg==}
     dependencies:
       undici-types: 6.21.0
+
+  /@types/node@7.10.14:
+    resolution: {integrity: sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==}
+    dev: false
 
   /@types/qrcode@1.5.5:
     resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
@@ -3551,7 +3554,7 @@ packages:
       cache-manager: 5.7.6
       futoin-hkdf: 1.5.3
       libphonenumber-js: 1.12.23
-      libsignal: git@github.com+WhiskeySockets/libsignal-node/e81ecfc32eb74951d789ab37f7e341ab66d5fff1
+      libsignal: 1.0.7
       lodash: 4.17.21
       music-metadata: 7.14.0
       node-cache: 5.1.2
@@ -3559,7 +3562,7 @@ packages:
       protobufjs: 7.5.4
       qrcode-terminal: 0.12.0
       uuid: 10.0.0
-      ws: 8.17.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -3967,10 +3970,6 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  /curve25519-js@0.0.4:
-    resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
-    dev: false
 
   /d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -5339,6 +5338,13 @@ packages:
     resolution: {integrity: sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==}
     dev: false
 
+  /libsignal@1.0.7:
+    resolution: {integrity: sha512-eU1M5EcJ4LRJGbqjwVjdJIupNCGRf1Kbl8SwM7ql5vRJCXhLOkbQ+Dv+zrOi8iICiH151PsfOmu4VMods5UaOQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      protobufjs: 6.8.0
+    dev: false
+
   /lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
     engines: {node: '>= 12.0.0'}
@@ -5539,8 +5545,9 @@ packages:
       triple-beam: 1.4.1
     dev: false
 
-  /long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+  /long@3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
     dev: false
 
   /long@5.3.2:
@@ -6145,8 +6152,8 @@ packages:
       react-is: 16.13.1
     dev: false
 
-  /protobufjs@6.8.8:
-    resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
+  /protobufjs@6.8.0:
+    resolution: {integrity: sha512-47Y49f5JN5Qsbxas2TyI2zFO8j9GpQAQm5thf54fr2O8qcP/jkIXYxmYx1hN2WQFAhESU1xpVn5NWVDBB8WFnw==}
     hasBin: true
     requiresBuild: true
     dependencies:
@@ -6160,9 +6167,9 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      '@types/node': 10.17.60
-      long: 4.0.0
+      '@types/long': 3.0.32
+      '@types/node': 7.10.14
+      long: 3.2.0
     dev: false
 
   /protobufjs@7.5.4:
@@ -7568,6 +7575,19 @@ packages:
         optional: true
     dev: false
 
+  /ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -7623,13 +7643,4 @@ packages:
 
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-    dev: false
-
-  git@github.com+WhiskeySockets/libsignal-node/e81ecfc32eb74951d789ab37f7e341ab66d5fff1:
-    resolution: {commit: e81ecfc32eb74951d789ab37f7e341ab66d5fff1, repo: git@github.com:WhiskeySockets/libsignal-node.git, type: git}
-    name: '@whiskeysockets/libsignal-node'
-    version: 2.0.1
-    dependencies:
-      curve25519-js: 0.0.4
-      protobufjs: 6.8.8
     dev: false


### PR DESCRIPTION
## Summary
- force `libsignal` to resolve from the npm registry via pnpm overrides so Render builds no longer require SSH access
- align the Baileys service override with the npm alias and clean up duplicated API build scripts
- regenerate the workspace lockfile to capture the new resolution and dependency graph

## Testing
- pnpm -F @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68db47fa58548332bdce1bbb85b0ee5c