### PR TITLE
Fix Vitest execution without generated Prisma client

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/server.ts",
     "prestart": "pnpm run build:dependencies && pnpm run db:generate",
     "start": "node dist/server.js",
-    "test": "vitest",
+    "test": "vitest --run",
     "test:watch": "vitest --watch",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist",

--- a/apps/api/src/routes/leads.test.ts
+++ b/apps/api/src/routes/leads.test.ts
@@ -2,12 +2,34 @@ import express from 'express';
 import request from 'supertest';
 import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
 import type { RequestHandler, Router } from 'express';
-import { LeadStatus, LeadSource } from '@prisma/client';
-
 const leadFindMany = vi.fn();
 const leadCount = vi.fn();
 const leadCreate = vi.fn();
 const contactFindUnique = vi.fn();
+
+const leadStatusMock = {
+  NEW: 'NEW',
+  CONTACTED: 'CONTACTED',
+  QUALIFIED: 'QUALIFIED',
+  CONVERTED: 'CONVERTED',
+  LOST: 'LOST',
+} as const;
+
+const leadSourceMock = {
+  WHATSAPP: 'WHATSAPP',
+  MANUAL: 'MANUAL',
+  PHONE: 'PHONE',
+  EMAIL: 'EMAIL',
+  OTHER: 'OTHER',
+} as const;
+
+vi.mock('@prisma/client', () => ({
+  LeadStatus: leadStatusMock,
+  LeadSource: leadSourceMock,
+}));
+
+let LeadStatus: typeof leadStatusMock = leadStatusMock;
+let LeadSource: typeof leadSourceMock = leadSourceMock;
 
 vi.mock('../lib/prisma', () => ({
   prisma: {
@@ -26,6 +48,7 @@ let leadsRouter: Router;
 let errorHandler: RequestHandler;
 
 beforeAll(async () => {
+  ({ LeadStatus, LeadSource } = await import('@prisma/client'));
   ({ leadsRouter } = await import('./leads'));
   ({ errorHandler } = await import('../middleware/error-handler'));
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
-    "test:watch": "vitest --watch",
+    "test": "vitest --passWithNoTests",
+    "test:watch": "vitest --watch --passWithNoTests",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
## Summary
- ensure workspace packages use Vitest's pass-with-no-tests mode to avoid CI failures when suites are absent
- mock `@prisma/client` in the leads route tests so Vitest can run without a generated Prisma client
- run the API package's Vitest suite in single-run mode instead of watch mode

## Testing
- pnpm --filter @ticketz/api test
- pnpm --filter @ticketz/core test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68db547649a88332a13a6e7883b32322