### PR TITLE
Refactor WhatsApp broker client for minimal HTTP mode

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,7 @@
+# WhatsApp broker configuration
+WHATSAPP_MODE=http
+WHATSAPP_BROKER_URL=https://your-broker-hostname
+WHATSAPP_BROKER_API_KEY=your-broker-api-key
+WHATSAPP_WEBHOOK_API_KEY=your-webhook-api-key
+# Optional: override default timeout (milliseconds) for broker HTTP requests
+# WHATSAPP_BROKER_TIMEOUT_MS=15000


### PR DESCRIPTION
## Summary
- refactor the WhatsApp broker client to read HTTP mode env vars, expose the new session/message/event APIs, and keep legacy wrappers for backwards compatibility
- surface broker error codes in thrown errors and support webhook API key usage for event polling/acking
- add targeted vitest coverage for the new HTTP contract and document the required env vars in `apps/api/.env.example`

## Testing
- `LEAD_ENGINE_BROKER_BASE_URL=https://leadengine.example LEAD_ENGINE_BASIC_TOKEN=token pnpm --filter @ticketz/api exec vitest run src/services/whatsapp-broker-client.test.ts src/routes/integrations.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68dc5da75dc0833287c11387d26ae992