### PR TITLE
feat: adapt whatsapp integrations to minimal broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,13 @@ GET    /api/lead-engine/agreements/available
 
 #### WhatsApp
 ```
-GET    /api/integrations/whatsapp/instances
-POST   /api/integrations/whatsapp/instances
-POST   /api/integrations/whatsapp/instances/:id/start
-POST   /api/integrations/whatsapp/instances/:id/stop
-GET    /api/integrations/whatsapp/instances/:id/qr
-POST   /api/integrations/whatsapp/instances/:id/send
+POST   /api/integrations/whatsapp/session/connect
+POST   /api/integrations/whatsapp/session/logout
+GET    /api/integrations/whatsapp/session/status
+POST   /api/integrations/whatsapp/messages
+POST   /api/integrations/whatsapp/polls
+GET    /api/integrations/whatsapp/events
+POST   /api/integrations/whatsapp/events/ack
 ```
 
 #### URA


### PR DESCRIPTION
## Summary
- replace the legacy WhatsApp instance routes with single-session orchestration that talks to the minimal broker
- add authenticated message, poll, and event endpoints that map tenant payloads to the broker contract and normalize responses
- refresh the public API guide with the new WhatsApp endpoints

## Testing
- pnpm --filter api test -- --runTestsByPath apps/api/src/services/whatsapp-broker-client.test.ts *(fails: command not found: pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68dc61266434833298f3fb442ce365ed