### PR TITLE
Fix WhatsApp broker polling ack handling

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -126,12 +126,12 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse(204));
     const client = await loadClient();
 
-    await client.ackEvents(['evt-1', 'evt-2']);
+    await client.ackEvents({ ids: ['evt-1', 'evt-2'] });
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://broker.example/broker/events/ack');
     const body = JSON.parse(String(init?.body));
-    expect(body).toEqual({ eventIds: ['evt-1', 'evt-2'] });
+    expect(body).toEqual({ ids: ['evt-1', 'evt-2'] });
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('webhook-key');
   });
@@ -139,7 +139,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
   it('does not call ackEvents when ids list is empty', async () => {
     const client = await loadClient();
 
-    await client.ackEvents([]);
+    await client.ackEvents({ ids: [] });
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -346,8 +346,14 @@ class WhatsAppBrokerClient {
     );
   }
 
-  async ackEvents(eventIds: string[]): Promise<void> {
-    if (!Array.isArray(eventIds) || eventIds.length === 0) {
+  async ackEvents(payload: { ids: string[] }): Promise<void> {
+    const ids = Array.isArray(payload?.ids)
+      ? payload.ids
+          .map((id) => (typeof id === 'string' ? id.trim() : ''))
+          .filter((id) => id.length > 0)
+      : [];
+
+    if (ids.length === 0) {
       return;
     }
 
@@ -355,7 +361,7 @@ class WhatsAppBrokerClient {
       '/broker/events/ack',
       {
         method: 'POST',
-        body: JSON.stringify({ eventIds }),
+        body: JSON.stringify({ ids }),
       },
       {
         apiKey: this.webhookApiKey,

--- a/apps/api/src/workers/whatsapp-event-poller.test.ts
+++ b/apps/api/src/workers/whatsapp-event-poller.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchEvents = vi.fn();
+const ackEvents = vi.fn();
+const enqueueWhatsAppBrokerEvents = vi.fn();
+
+const integrationStateFindUnique = vi.fn();
+const integrationStateUpsert = vi.fn();
+const processedIntegrationEventFindMany = vi.fn();
+const processedIntegrationEventCreateMany = vi.fn();
+const processedIntegrationEventDeleteMany = vi.fn();
+
+vi.mock('../config/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../services/whatsapp-broker-client', () => ({
+  whatsappBrokerClient: {
+    fetchEvents,
+    ackEvents,
+  },
+  WhatsAppBrokerNotConfiguredError: class extends Error {},
+}));
+
+vi.mock('../lib/prisma', () => ({
+  prisma: {
+    $transaction: vi.fn(async (operations: Array<Promise<unknown>>) => Promise.all(operations)),
+    integrationState: {
+      findUnique: integrationStateFindUnique,
+      upsert: integrationStateUpsert,
+    },
+    processedIntegrationEvent: {
+      findMany: processedIntegrationEventFindMany,
+      createMany: processedIntegrationEventCreateMany,
+      deleteMany: processedIntegrationEventDeleteMany,
+    },
+  },
+}));
+
+vi.mock('./whatsapp-event-queue', async () => {
+  const actual = await vi.importActual<typeof import('./whatsapp-event-queue')>('./whatsapp-event-queue');
+  return {
+    ...actual,
+    enqueueWhatsAppBrokerEvents,
+    getWhatsAppEventQueueStats: () => ({ pending: 0 }),
+  };
+});
+
+describe('WhatsApp event poller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('processes broker items and acknowledges them', async () => {
+    fetchEvents.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'evt-1',
+          type: 'MESSAGE_INBOUND',
+          payload: { text: 'hello' },
+          tenantId: 'tenant-1',
+          sessionId: 'session-1',
+        },
+        {
+          id: 'evt-2',
+          type: 'MESSAGE_OUTBOUND',
+          payload: { text: 'bye' },
+        },
+      ],
+      nextId: ' cursor-2 ',
+    });
+    ackEvents.mockResolvedValueOnce(undefined);
+    processedIntegrationEventFindMany.mockResolvedValueOnce([]);
+    processedIntegrationEventCreateMany.mockResolvedValueOnce({ count: 2 });
+    integrationStateUpsert.mockResolvedValue(undefined);
+
+    const module = await import('./whatsapp-event-poller');
+    const poller = new (module.whatsappEventPoller as unknown as { constructor: new () => unknown }).constructor() as Record<string, unknown>;
+
+    const processedCount = await (poller as { pollOnce: () => Promise<number> }).pollOnce();
+
+    expect(processedCount).toBe(2);
+    expect(fetchEvents).toHaveBeenCalledWith({ limit: 50, cursor: undefined });
+    expect(processedIntegrationEventFindMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['evt-1', 'evt-2'] },
+        source: 'whatsapp-broker',
+      },
+      select: { id: true },
+    });
+    expect(processedIntegrationEventCreateMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({ id: 'evt-1', type: 'MESSAGE_INBOUND' }),
+        expect.objectContaining({ id: 'evt-2', type: 'MESSAGE_OUTBOUND' }),
+      ]),
+      skipDuplicates: true,
+    });
+    expect(enqueueWhatsAppBrokerEvents).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'evt-1', type: 'MESSAGE_INBOUND' }),
+      expect.objectContaining({ id: 'evt-2', type: 'MESSAGE_OUTBOUND' }),
+    ]);
+    expect(ackEvents).toHaveBeenCalledTimes(1);
+    expect(ackEvents).toHaveBeenCalledWith({ ids: ['evt-1', 'evt-2'] });
+
+    expect(integrationStateUpsert).toHaveBeenCalledWith({
+      where: { key: 'whatsapp:last-ack' },
+      create: expect.objectContaining({
+        key: 'whatsapp:last-ack',
+        value: expect.objectContaining({ cursor: 'cursor-2', count: 2 }),
+      }),
+      update: expect.objectContaining({
+        value: expect.objectContaining({ cursor: 'cursor-2', count: 2 }),
+      }),
+    });
+
+    expect(integrationStateUpsert).toHaveBeenCalledWith({
+      where: { key: 'whatsapp:event-cursor' },
+      create: expect.objectContaining({ value: { cursor: 'cursor-2' } }),
+      update: { value: { cursor: 'cursor-2' } },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update the WhatsApp broker poller to consume `items`, persist the next cursor/id and acknowledge events with the new payload format
- adapt the broker client, HTTP routes and existing tests to the `{ ids: [...] }` acknowledgment contract
- add unit coverage ensuring the poller persists processed events and acknowledges broker deliveries

## Testing
- pnpm --filter @ticketz/api test -- src/services/whatsapp-broker-client.test.ts src/workers/whatsapp-event-poller.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc689523808332adead40967520304