### PR TITLE
Update WhatsApp integration routes to new broker payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ GET    /api/integrations/whatsapp/events
 POST   /api/integrations/whatsapp/events/ack
 ```
 
+- `POST /api/integrations/whatsapp/messages`
+  - Corpo: `{ to, text, previewUrl?, externalId?, waitAckMs?, timeoutMs?, skipNormalize?, instanceId? }`
+  - Resposta: `{ success, data: { externalId, status, ack, ackAt, rate } }` (HTTP 201 quando aceito pelo broker)
+- `POST /api/integrations/whatsapp/polls`
+  - Corpo: `{ to, question, options, selectableCount?, instanceId? }`
+- `GET /api/integrations/whatsapp/events`
+  - Query string: `limit?`, `after?`, `instanceId?`
+  - Resposta: `{ success, data: { items, nextCursor, ack, ackAt, rate } }`
+- `POST /api/integrations/whatsapp/events/ack`
+  - Corpo: `{ ids: string[] }`
+  - Resposta: `{ success, data: { ack: { ids }, ackAt } }`
+
 #### Webhooks
 ```
 POST   /api/integrations/whatsapp/webhook

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -47,7 +47,7 @@ export const errorHandler = (
   let apiError: ApiError;
 
   // Tratar diferentes tipos de erro
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error.name === 'ValidationError') {
     apiError = {
       status: 400,
       code: 'VALIDATION_ERROR',

--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -69,7 +69,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse(200, { id: 'msg-1' }));
     const client = await loadClient();
 
-    await client.sendText({ sessionId: 'session-1', to: '5511987654321', message: 'Hello' });
+    await client.sendText({ sessionId: 'session-1', to: '5511987654321', text: 'Hello' });
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://broker.example/broker/messages');
@@ -78,8 +78,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     expect(body).toEqual({
       sessionId: 'session-1',
       to: '5511987654321',
-      message: 'Hello',
-      type: 'text',
+      text: 'Hello',
     });
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('broker-key');
@@ -94,7 +93,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
       to: '5511987654321',
       question: 'Qual opção?',
       options: ['A', 'B', 'C'],
-      allowMultipleAnswers: true,
+      selectableCount: 2,
     });
 
     const [url, init] = fetchMock.mock.calls[0];
@@ -105,7 +104,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
       to: '5511987654321',
       question: 'Qual opção?',
       options: ['A', 'B', 'C'],
-      allowMultipleAnswers: true,
+      selectableCount: 2,
     });
   });
 
@@ -113,10 +112,10 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse(200, { events: [] }));
     const client = await loadClient();
 
-    await client.fetchEvents({ limit: 10, cursor: 'abc' });
+    await client.fetchEvents({ limit: 10, after: 'abc' });
 
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('https://broker.example/broker/events?limit=10&cursor=abc');
+    expect(url).toBe('https://broker.example/broker/events?limit=10&after=abc');
     expect(init?.method).toBe('GET');
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('webhook-key');
@@ -131,7 +130,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://broker.example/broker/events/ack');
     const body = JSON.parse(String(init?.body));
-    expect(body).toEqual({ eventIds: ['evt-1', 'evt-2'] });
+    expect(body).toEqual({ ids: ['evt-1', 'evt-2'] });
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('webhook-key');
   });
@@ -151,7 +150,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     const client = await loadClient();
 
     await expect(
-      client.sendText({ sessionId: 'session-1', to: '5511987654321', message: 'Hello' })
+      client.sendText({ sessionId: 'session-1', to: '5511987654321', text: 'Hello' })
     ).rejects.toMatchObject({
       name: 'WhatsAppBrokerError',
       code: 'RATE_LIMIT_EXCEEDED',
@@ -166,7 +165,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     );
     const client = await loadClient();
 
-    const promise = client.sendText({ sessionId: 'session-1', to: '5511987654321', message: 'Hello' });
+    const promise = client.sendText({ sessionId: 'session-1', to: '5511987654321', text: 'Hello' });
 
     await expect(promise).rejects.toMatchObject({
       name: 'WhatsAppBrokerNotConfiguredError',


### PR DESCRIPTION
## Summary
- rename WhatsApp integration payloads to accept text options, instance identifiers, and expose ack metadata
- update broker client and event poller to honor new waitAck, after/ids semantics and improved error handling
- document the refreshed contract and harden validation error handling for consistent HTTP responses

## Testing
- pnpm --filter @ticketz/api test

------
https://chatgpt.com/codex/tasks/task_e_68dc687f2c4883328f9ed2fc3e0862bd