### PR TITLE
refactor: align whatsapp broker client with new contract

### DIFF
--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -47,7 +47,7 @@ export const errorHandler = (
   let apiError: ApiError;
 
   // Tratar diferentes tipos de erro
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error.name === 'ValidationError') {
     apiError = {
       status: 400,
       code: 'VALIDATION_ERROR',

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -131,11 +131,41 @@ const normalizeSessionStatus = (status: BrokerSessionStatus | null | undefined) 
     return null;
   })();
 
+  const qr = (() => {
+    if (qrSource) {
+      const content = typeof qrSource.content === 'string' ? qrSource.content.trim() : '';
+      if (content.length > 0) {
+        return {
+          content,
+          expiresAt: typeof qrSource.expiresAt === 'string' ? qrSource.expiresAt : qrExpiresAt,
+        };
+      }
+    }
+
+    if (qrCode) {
+      return {
+        content: qrCode,
+        expiresAt: qrExpiresAt,
+      };
+    }
+
+    return null;
+  })();
+
+  const user = (() => {
+    if (status?.user && typeof status.user === 'object') {
+      return status.user;
+    }
+    return null;
+  })();
+
   return {
     status: normalizedStatus,
     connected,
     qrCode,
     qrExpiresAt,
+    qr,
+    user,
     rate: parseRateLimit(status?.rate ?? null),
   };
 };

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -29,6 +29,175 @@ const router: Router = Router();
 // WhatsApp Routes
 // ============================================================================
 
+router.get(
+  '/whatsapp/instances',
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const tenantId = req.user!.tenantId;
+
+    try {
+      const instances = await whatsappBrokerClient.listInstances(tenantId);
+
+      res.json({
+        success: true,
+        data: instances,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/whatsapp/instances',
+  body('name').isString().isLength({ min: 1 }),
+  body('webhookUrl').optional().isURL(),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const tenantId = req.user!.tenantId;
+    const { name, webhookUrl } = req.body as { name: string; webhookUrl?: string };
+
+    try {
+      const instance = await whatsappBrokerClient.createInstance({
+        tenantId,
+        name,
+        webhookUrl,
+      });
+
+      res.status(201).json({
+        success: true,
+        data: instance,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/whatsapp/instances/:id/start',
+  param('id').isString().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const instanceId = req.params.id;
+
+    try {
+      await whatsappBrokerClient.connectInstance(instanceId);
+
+      res.status(202).json({
+        success: true,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.post(
+  '/whatsapp/instances/:id/stop',
+  param('id').isString().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const instanceId = req.params.id;
+
+    try {
+      await whatsappBrokerClient.disconnectInstance(instanceId);
+
+      res.json({
+        success: true,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.delete(
+  '/whatsapp/instances/:id',
+  param('id').isString().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const instanceId = req.params.id;
+
+    try {
+      await whatsappBrokerClient.deleteInstance(instanceId);
+
+      res.json({
+        success: true,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/whatsapp/instances/:id/status',
+  param('id').isString().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const instanceId = req.params.id;
+
+    try {
+      const status = await whatsappBrokerClient.getStatus(instanceId);
+
+      res.json({
+        success: true,
+        data: status,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
+router.get(
+  '/whatsapp/instances/:id/qr',
+  param('id').isString().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const instanceId = req.params.id;
+
+    try {
+      const qrCode = await whatsappBrokerClient.getQrCode(instanceId);
+
+      res.json({
+        success: true,
+        data: qrCode,
+      });
+    } catch (error) {
+      if (respondWhatsAppNotConfigured(res, error)) {
+        return;
+      }
+      throw error;
+    }
+  })
+);
+
 type BrokerRateLimit = {
   limit: number | null;
   remaining: number | null;


### PR DESCRIPTION
## Summary
- align the WhatsApp broker client with the latest payload contract, including instance-based session calls, ack parsing, and status normalization
- map new broker response fields such as items, pending, and ack while updating integrations routes to surface the normalized data
- rewrite the WhatsApp broker client tests to cover the updated request headers and response handling

## Testing
- pnpm --filter @ticketz/api test *(fails: existing suite reports 500 instead of expected 400 on Lead Engine validation and 404 HTML responses for WhatsApp instance routes when the broker is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6872f08c8332b412d95ebd481a45