### PR TITLE
Fix WhatsApp broker timeout test payload field

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -190,7 +190,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     });
 
     const client = await loadClient();
-    const promise = client.sendText({ sessionId: 'session-1', to: '5511987654321', message: 'Hello' });
+    const promise = client.sendText({ sessionId: 'session-1', to: '5511987654321', text: 'Hello' });
     const expectation = expect(promise).rejects.toMatchObject({
       code: 'REQUEST_TIMEOUT',
       name: 'WhatsAppBrokerError',


### PR DESCRIPTION
## Summary
- update the WhatsApp broker timeout test to send the text field expected by sendText

## Testing
- `pnpm --filter @ticketz/api test` *(fails: existing lead engine and integrations tests report validation/json handling errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6ce2ffb48332a97f34b3620f1e64