### PR TITLE
feat(api): add WhatsApp instance management routes

### DIFF
--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -30,13 +30,21 @@ const restoreWhatsAppEnv = () => {
 };
 
 afterEach(() => {
+  vi.restoreAllMocks();
   restoreWhatsAppEnv();
 });
 
-const startTestServer = async () => {
+const startTestServer = async ({
+  configureWhatsApp = false,
+}: { configureWhatsApp?: boolean } = {}) => {
   vi.resetModules();
-  delete process.env.WHATSAPP_BROKER_URL;
-  delete process.env.WHATSAPP_BROKER_API_KEY;
+  if (configureWhatsApp) {
+    process.env.WHATSAPP_BROKER_URL = 'http://broker.test';
+    process.env.WHATSAPP_BROKER_API_KEY = 'test-key';
+  } else {
+    delete process.env.WHATSAPP_BROKER_URL;
+    delete process.env.WHATSAPP_BROKER_API_KEY;
+  }
 
   const { integrationsRouter } = await import('./integrations');
 
@@ -79,6 +87,17 @@ const stopTestServer = (server: Server) =>
 describe('WhatsApp integration routes when broker is not configured', () => {
   const whatsappRoutes = [
     {
+      name: 'list instances',
+      method: 'GET',
+      path: '/whatsapp/instances',
+    },
+    {
+      name: 'create instance',
+      method: 'POST',
+      path: '/whatsapp/instances',
+      body: { name: 'Test Instance' },
+    },
+    {
       name: 'start instance',
       method: 'POST',
       path: '/whatsapp/instances/test-instance/start',
@@ -89,31 +108,279 @@ describe('WhatsApp integration routes when broker is not configured', () => {
       path: '/whatsapp/instances/test-instance/stop',
     },
     {
-      name: 'delete instance',
-      method: 'DELETE',
-      path: '/whatsapp/instances/test-instance',
+      name: 'get QR code',
+      method: 'GET',
+      path: '/whatsapp/instances/test-instance/qr',
+    },
+    {
+      name: 'get status',
+      method: 'GET',
+      path: '/whatsapp/instances/test-instance/status',
     },
   ] as const;
 
-  it.each(whatsappRoutes)('responds with 503 for %s', async ({ method, path }) => {
+  it.each(whatsappRoutes)('responds with 503 for %s', async ({ method, path, body }) => {
     const { server, url } = await startTestServer();
 
     try {
       const response = await fetch(`${url}/api/integrations${path}`, {
         method,
         headers: {
-          'content-type': 'application/json',
+          ...(body ? { 'content-type': 'application/json' } : {}),
+          'x-tenant-id': 'tenant-123',
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(responseBody).toMatchObject({
+        success: false,
+        error: {
+          code: 'WHATSAPP_NOT_CONFIGURED',
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+});
+
+describe('WhatsApp integration routes with configured broker', () => {
+  it('lists WhatsApp instances', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const listSpy = vi.spyOn(whatsappBrokerClient, 'listInstances').mockResolvedValue([
+      {
+        id: 'instance-1',
+        tenantId: 'tenant-123',
+        name: 'Main Instance',
+        status: 'CONNECTED',
+        connected: true,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        lastActivity: null,
+        stats: { sent: 10 },
+      },
+    ]);
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/instances`, {
+        method: 'GET',
+        headers: {
           'x-tenant-id': 'tenant-123',
         },
       });
 
       const body = await response.json();
 
-      expect(response.status).toBe(503);
+      expect(listSpy).toHaveBeenCalledWith('tenant-123');
+      expect(response.status).toBe(200);
       expect(body).toMatchObject({
-        success: false,
-        error: {
-          code: 'WHATSAPP_NOT_CONFIGURED',
+        success: true,
+        data: [
+          {
+            id: 'instance-1',
+            name: 'Main Instance',
+            status: 'connected',
+            connected: true,
+            tenantId: 'tenant-123',
+            lastActivity: null,
+            stats: { sent: 10 },
+          },
+        ],
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('creates a WhatsApp instance', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const createSpy = vi.spyOn(whatsappBrokerClient, 'createInstance').mockResolvedValue({
+      id: 'instance-2',
+      tenantId: 'tenant-123',
+      name: 'Created Instance',
+      status: 'connecting',
+      connected: false,
+      createdAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/instances`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({ name: 'Created Instance' }),
+      });
+
+      const body = await response.json();
+
+      expect(createSpy).toHaveBeenCalledWith({
+        tenantId: 'tenant-123',
+        name: 'Created Instance',
+        webhookUrl: undefined,
+      });
+      expect(response.status).toBe(201);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          id: 'instance-2',
+          name: 'Created Instance',
+          status: 'connecting',
+          connected: false,
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('connects a WhatsApp instance', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const connectSpy = vi.spyOn(whatsappBrokerClient, 'connectInstance').mockResolvedValue();
+    const statusSpy = vi
+      .spyOn(whatsappBrokerClient, 'getStatus')
+      .mockResolvedValue({ status: 'connected', connected: true });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/instance-3/start`,
+        {
+          method: 'POST',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        }
+      );
+
+      const body = await response.json();
+
+      expect(connectSpy).toHaveBeenCalledWith('instance-3');
+      expect(statusSpy).toHaveBeenCalledWith('instance-3');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          status: 'connected',
+          connected: true,
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('disconnects a WhatsApp instance', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const disconnectSpy = vi
+      .spyOn(whatsappBrokerClient, 'disconnectInstance')
+      .mockResolvedValue();
+    const statusSpy = vi
+      .spyOn(whatsappBrokerClient, 'getStatus')
+      .mockResolvedValue({ status: 'disconnected', connected: false });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/instance-4/stop`,
+        {
+          method: 'POST',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        }
+      );
+
+      const body = await response.json();
+
+      expect(disconnectSpy).toHaveBeenCalledWith('instance-4');
+      expect(statusSpy).toHaveBeenCalledWith('instance-4');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          status: 'disconnected',
+          connected: false,
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('fetches a WhatsApp instance QR code', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const qrSpy = vi.spyOn(whatsappBrokerClient, 'getQrCode').mockResolvedValue({
+      qrCode: 'data:image/png;base64,QR',
+      expiresAt: '2024-01-03T00:00:00.000Z',
+    });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/instance-5/qr`,
+        {
+          method: 'GET',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        }
+      );
+
+      const body = await response.json();
+
+      expect(qrSpy).toHaveBeenCalledWith('instance-5');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          qrCode: 'data:image/png;base64,QR',
+          expiresAt: '2024-01-03T00:00:00.000Z',
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('retrieves WhatsApp instance status', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const statusSpy = vi
+      .spyOn(whatsappBrokerClient, 'getStatus')
+      .mockResolvedValue({ status: 'qr_required', connected: false });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/instance-6/status`,
+        {
+          method: 'GET',
+          headers: {
+            'x-tenant-id': 'tenant-123',
+          },
+        }
+      );
+
+      const body = await response.json();
+
+      expect(statusSpy).toHaveBeenCalledWith('instance-6');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          status: 'qr_required',
+          connected: false,
         },
       });
     } finally {


### PR DESCRIPTION
## Summary
- add WhatsApp instance listing, creation, connection, disconnection, QR, and status endpoints that reuse existing middleware
- normalize broker responses into the UI-friendly `{ success, data }` shape and surface missing broker instances as 503s
- expand integration route tests to cover the new endpoints in both configured and not-configured scenarios

## Testing
- pnpm --filter @ticketz/api test *(fails: known auth middleware fallback and lead-engine validation cases present before this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0c522d9483328c79ce806e79001a