### PR TITLE
feat: fetch WhatsApp QR code from broker

### DIFF
--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -353,6 +353,39 @@ describe('WhatsApp integration routes with configured broker', () => {
     }
   });
 
+  it('fetches the default WhatsApp instance QR code', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const qrSpy = vi.spyOn(whatsappBrokerClient, 'getQrCode').mockResolvedValue({
+      qrCode: 'data:image/png;base64,DEFAULT_QR',
+      expiresAt: '2024-01-04T00:00:00.000Z',
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/instances/qr`, {
+        method: 'GET',
+        headers: {
+          'x-tenant-id': 'tenant-123',
+        },
+      });
+
+      const body = await response.json();
+
+      expect(qrSpy).toHaveBeenCalledWith('leadengine');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          qrCode: 'data:image/png;base64,DEFAULT_QR',
+          expiresAt: '2024-01-04T00:00:00.000Z',
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
   it('retrieves WhatsApp instance status', async () => {
     const { server, url } = await startTestServer({ configureWhatsApp: true });
     const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -407,8 +407,45 @@ class WhatsAppBrokerClient {
     await this.logoutSession(instanceId);
   }
 
-  async getQrCode(_instanceId: string): Promise<WhatsAppQrCode> {
+  async getQrCode(instanceId: string): Promise<WhatsAppQrCode> {
     this.ensureConfigured();
+
+    try {
+      const payload = await this.request<WhatsAppQrCode & Record<string, unknown>>(
+        '/broker/session/qr',
+        { method: 'GET' },
+        { searchParams: { sessionId: instanceId } }
+      );
+
+      if (payload && typeof payload === 'object') {
+        const qrCode = typeof payload.qrCode === 'string' ? payload.qrCode : undefined;
+        const expiresAt = typeof payload.expiresAt === 'string' ? payload.expiresAt : undefined;
+
+        if (qrCode && expiresAt) {
+          return { qrCode, expiresAt };
+        }
+
+        logger.warn('WhatsApp broker returned incomplete QR payload', {
+          instanceId,
+          payload,
+        });
+      } else {
+        logger.warn('WhatsApp broker returned invalid QR payload', {
+          instanceId,
+          payload,
+        });
+      }
+    } catch (error) {
+      if (error instanceof WhatsAppBrokerNotConfiguredError) {
+        throw error;
+      }
+
+      logger.warn('Failed to fetch WhatsApp QR code from broker; using fallback', {
+        instanceId,
+        error,
+      });
+    }
+
     return {
       qrCode: FALLBACK_QR,
       expiresAt: new Date(Date.now() + QR_EXPIRATION_MS).toISOString(),


### PR DESCRIPTION
## Summary
- request the WhatsApp QR code from the broker endpoint and keep the broker payload when available
- fall back to the static QR only on failures and add dedicated unit coverage
- ensure the integrations QR routes propagate the broker response and add route tests for the default session

## Testing
- pnpm --filter @ticketz/api exec vitest --run src/services/whatsapp-broker-client.test.ts
- pnpm --filter @ticketz/api exec vitest --run src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd1b8cdd888332993870527206d60c