### PR TITLE
feat: support wiping WhatsApp sessions on disconnect

### DIFF
--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -302,8 +302,96 @@ describe('WhatsApp integration routes with configured broker', () => {
 
       const body = await response.json();
 
-      expect(disconnectSpy).toHaveBeenCalledWith('instance-4');
+      expect(disconnectSpy).toHaveBeenCalledWith('instance-4', undefined);
       expect(statusSpy).toHaveBeenCalledWith('instance-4');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          status: 'disconnected',
+          connected: false,
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it.each([
+    { wipe: true },
+    { wipe: false },
+  ])('disconnects a WhatsApp instance with wipe %s', async ({ wipe }) => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const disconnectSpy = vi
+      .spyOn(whatsappBrokerClient, 'disconnectInstance')
+      .mockResolvedValue();
+    const statusSpy = vi
+      .spyOn(whatsappBrokerClient, 'getStatus')
+      .mockResolvedValue({ status: 'disconnected', connected: false });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/instance-4/stop`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-tenant-id': 'tenant-123',
+          },
+          body: JSON.stringify({ wipe }),
+        }
+      );
+
+      const body = await response.json();
+
+      expect(disconnectSpy).toHaveBeenCalledWith('instance-4', { wipe });
+      expect(statusSpy).toHaveBeenCalledWith('instance-4');
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          status: 'disconnected',
+          connected: false,
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it.each([
+    { wipe: true },
+    { wipe: false },
+  ])('disconnects the default WhatsApp instance with wipe %s', async ({ wipe }) => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const { whatsappBrokerClient } = await import('../services/whatsapp-broker-client');
+
+    const disconnectSpy = vi
+      .spyOn(whatsappBrokerClient, 'disconnectInstance')
+      .mockResolvedValue();
+    const statusSpy = vi
+      .spyOn(whatsappBrokerClient, 'getStatus')
+      .mockResolvedValue({ status: 'disconnected', connected: false });
+
+    try {
+      const response = await fetch(
+        `${url}/api/integrations/whatsapp/instances/disconnect`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-tenant-id': 'tenant-123',
+          },
+          body: JSON.stringify({ wipe }),
+        }
+      );
+
+      const body = await response.json();
+
+      expect(disconnectSpy).toHaveBeenCalledWith('leadengine', { wipe });
+      expect(statusSpy).toHaveBeenCalledWith('leadengine');
       expect(response.status).toBe(200);
       expect(body).toMatchObject({
         success: true,

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -332,13 +332,16 @@ router.post(
 router.post(
   '/whatsapp/instances/:id/stop',
   param('id').isString().isLength({ min: 1 }),
+  body('wipe').optional().isBoolean(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {
     const instanceId = req.params.id;
+    const wipe = typeof req.body?.wipe === 'boolean' ? req.body.wipe : undefined;
+    const disconnectOptions = wipe === undefined ? undefined : { wipe };
 
     try {
-      await whatsappBrokerClient.disconnectInstance(instanceId);
+      await whatsappBrokerClient.disconnectInstance(instanceId, disconnectOptions);
       const status = await whatsappBrokerClient.getStatus(instanceId);
 
       res.json({
@@ -357,12 +360,16 @@ router.post(
 // POST /api/integrations/whatsapp/instances/disconnect - Disconnect the default WhatsApp instance
 router.post(
   '/whatsapp/instances/disconnect',
+  body('wipe').optional().isBoolean(),
+  validateRequest,
   requireTenant,
-  asyncHandler(async (_req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const instanceId = resolveDefaultInstanceId();
+    const wipe = typeof req.body?.wipe === 'boolean' ? req.body.wipe : undefined;
+    const disconnectOptions = wipe === undefined ? undefined : { wipe };
 
     try {
-      await whatsappBrokerClient.disconnectInstance(instanceId);
+      await whatsappBrokerClient.disconnectInstance(instanceId, disconnectOptions);
       const status = await whatsappBrokerClient.getStatus(instanceId);
 
       res.json({

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -264,10 +264,10 @@ class WhatsAppBrokerClient {
     );
   }
 
-  async logoutSession(sessionId: string): Promise<void> {
+  async logoutSession(sessionId: string, options: { wipe?: boolean } = {}): Promise<void> {
     await this.request<void>('/broker/session/logout', {
       method: 'POST',
-      body: JSON.stringify({ sessionId }),
+      body: JSON.stringify(compactObject({ sessionId, wipe: options.wipe })),
     });
   }
 
@@ -399,12 +399,12 @@ class WhatsAppBrokerClient {
     await this.connectSession(instanceId);
   }
 
-  async disconnectInstance(instanceId: string): Promise<void> {
-    await this.logoutSession(instanceId);
+  async disconnectInstance(instanceId: string, options: { wipe?: boolean } = {}): Promise<void> {
+    await this.logoutSession(instanceId, options);
   }
 
-  async deleteInstance(instanceId: string): Promise<void> {
-    await this.logoutSession(instanceId);
+  async deleteInstance(instanceId: string, options: { wipe?: boolean } = {}): Promise<void> {
+    await this.logoutSession(instanceId, options);
   }
 
   async getQrCode(_instanceId: string): Promise<WhatsAppQrCode> {


### PR DESCRIPTION
## Summary
- allow WhatsApp disconnect routes to accept an optional wipe flag and forward it to the service layer
- include the wipe option when logging out sessions from the broker
- add route tests covering wipe true/false payloads and broker invocation expectations

## Testing
- pnpm --filter @ticketz/api test -- src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd1b90b0d48332878c0e05f0bc42b2