### PR TITLE
feat: poll whatsapp instances periodically

### DIFF
--- a/apps/web/src/components/WhatsAppConnect.jsx
+++ b/apps/web/src/components/WhatsAppConnect.jsx
@@ -233,10 +233,27 @@ const WhatsAppConnect = ({
   }, [activeCampaign]);
 
   useEffect(() => {
-    if (!selectedAgreement) return;
-    void loadInstances();
+    if (!selectedAgreement?.id || !authToken) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const poll = () => {
+      if (cancelled) return;
+      if (loadingInstances || loadingQr) return;
+      void loadInstancesRef.current?.();
+    };
+
+    poll();
+    const interval = setInterval(poll, 5000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedAgreement?.id]);
+  }, [selectedAgreement?.id, authToken, loadingInstances, loadingQr]);
 
   useEffect(() => {
     if (!selectedAgreement) {


### PR DESCRIPTION
## Summary
- add an authentication-aware polling effect to refresh WhatsApp instances when an agreement is selected
- prevent redundant requests by reusing the polling ref and skipping while existing loads are running

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd229ffc2c833299048ec18e54e654