### PR TITLE
Allow x-api-key header in API CORS configuration

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -64,7 +64,7 @@ const resolvedCorsOrigins = Array.from(corsAllowedOrigins);
 const sharedCorsSettings = {
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as string[],
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-tenant-id', 'Accept'] as string[],
+  allowedHeaders: ['Content-Type', 'Authorization', 'x-tenant-id', 'Accept', 'x-api-key'] as string[],
 };
 
 const corsOptions: CorsOptions = allowAllOrigins


### PR DESCRIPTION
## Summary
- include the `x-api-key` header in the shared CORS configuration so preflight requests allow it

## Testing
- curl -i -X OPTIONS http://localhost:4000/health -H "Origin: https://leadengine-corban.onrender.com" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: x-api-key"


------
https://chatgpt.com/codex/tasks/task_e_68dd2904c5708332868306c32906e616