### PR TITLE
Align WhatsApp broker session handling with session status endpoint

### DIFF
--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -68,6 +68,7 @@ const WHATSAPP_BROKER_ERROR_MESSAGES: Record<string, string> = {
   INVALID_SESSION: 'WhatsApp session is invalid or unavailable',
   SESSION_NOT_FOUND: 'WhatsApp session not found',
   MESSAGE_REJECTED: 'WhatsApp message was rejected by the broker',
+  BROKER_AUTH: 'WhatsApp broker authentication failed',
   BROKER_ERROR: 'WhatsApp broker request failed',
   INTERNAL_ERROR: 'WhatsApp broker encountered an internal error',
 };

--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -165,24 +165,21 @@ describe('WhatsApp integration routes with configured broker', () => {
     const listSpy = vi.spyOn(whatsappBrokerClient, 'listInstances').mockResolvedValue([
       {
         id: 'instance-1',
-        status: 'CONNECTED',
+        tenantId: 'tenant-123',
+        name: 'Main Instance',
+        status: 'connected',
+        connected: true,
         createdAt: '2024-01-01T00:00:00.000Z',
-        metadata: {
-          tenant_id: 'tenant-123',
-          name: 'Main Instance',
-          last_activity: '2024-01-02T00:00:00.000Z',
-          phone_number: '+5511987654321',
-          user: 'Agent Smith',
-          stats: { sent: 10 },
-        },
+        lastActivity: '2024-01-02T00:00:00.000Z',
+        phoneNumber: '+5511987654321',
+        user: 'Agent Smith',
+        stats: { sent: 10 },
       },
       {
-        metadata: {
-          sessionId: 'instance-2',
-          tenantId: 'tenant-123',
-          status: 'DISCONNECTED',
-          connected: false,
-        },
+        id: 'instance-2',
+        tenantId: 'tenant-123',
+        status: 'disconnected',
+        connected: false,
       },
     ] as unknown as typeof whatsappBrokerClient.listInstances extends (...args: any[]) => infer R
       ? R extends Promise<infer I>

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -57,6 +57,10 @@ type BrokerInstance = {
   phoneNumber?: string | null;
   user?: string | null;
   stats?: unknown;
+  metadata?: Record<string, unknown> | null;
+  profile?: Record<string, unknown> | null;
+  details?: Record<string, unknown> | null;
+  info?: Record<string, unknown> | null;
 };
 
 type NormalizedInstance = {
@@ -112,10 +116,17 @@ const normalizeInstance = (instance: unknown): NormalizedInstance | null => {
   }
 
   const source = instance as BrokerInstance & Record<string, unknown>;
-  const metadata =
-    source.metadata && typeof source.metadata === 'object'
-      ? (source.metadata as Record<string, unknown>)
-      : {};
+
+  const metadataSources = [
+    source.metadata,
+    source.profile,
+    source.details,
+    source.info,
+  ].filter((value): value is Record<string, unknown> => Boolean(value && typeof value === 'object'));
+
+  const metadata = metadataSources.reduce<Record<string, unknown>>((acc, entry) => {
+    return { ...acc, ...entry };
+  }, {});
 
   const idCandidate = [
     source.id,


### PR DESCRIPTION
## Summary
- update the WhatsApp broker client to fetch the default session status via the session status endpoints, normalize the payload, and improve error mapping for broker authentication failures
- adjust WhatsApp integration normalization to merge metadata sources and propagate phone, user, and name fields while adapting tests to the new single-instance shape
- extend broker error messaging to cover authentication errors for clearer API responses

## Testing
- pnpm --filter @ticketz/api test *(fails: known auth middleware fallback expectations in src/middleware/auth.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b5629e4833298426b5131c037ec