### PR TITLE
Allow WhatsApp UI to remain active without stored token

### DIFF
--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -81,7 +81,11 @@ const handleResponse = async (response) => {
   const payload = await response.json().catch(() => ({}));
   if (!response.ok || payload?.success === false) {
     const errorMessage = payload?.error?.message || response.statusText;
-    throw new Error(errorMessage || 'Erro ao comunicar com a API');
+    const error = new Error(errorMessage || 'Erro ao comunicar com a API');
+    error.status = response.status;
+    error.statusText = response.statusText;
+    error.payload = payload;
+    throw error;
   }
   return payload;
 };


### PR DESCRIPTION
## Summary
- track a sessionActive flag that stays true when WhatsApp API calls succeed so the UI remains usable without a stored auth token
- surface the demo login prompt only when WhatsApp endpoints respond with 401/403 and reuse a shared handler across instance, QR, and status flows
- expose HTTP status codes from the shared API helper for reliable auth error detection

## Testing
- pnpm --filter web lint *(fails: pre-existing lint error in apps/web/src/components/Dashboard.jsx and warnings in shared UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4908ce508332b1b3149d1f6289f2