### PR TITLE
Ensure WhatsApp listInstances uses broker credentials

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -87,9 +87,9 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('https://broker.example/broker/session/status');
+    expect(url).toBe('https://broker.example/broker/session/status?tenantId=tenant-123');
     expect(init?.method).toBe('GET');
-    expect((init?.headers as Headers).get('x-api-key')).toBe('tenant-123');
+    expect((init?.headers as Headers).get('x-api-key')).toBe('broker-key');
 
     expect(instances).toHaveLength(1);
     expect(instances[0]).toMatchObject({
@@ -103,6 +103,35 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
       phoneNumber: '+5511987654321',
       user: 'Agent Smith',
       stats: { sent: 10 },
+    });
+  });
+
+  it('listInstances uses broker credentials without tenant filter by default', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        id: 'instance-2',
+        status: 'DISCONNECTED',
+        metadata: {
+          tenantId: 'tenant-from-broker',
+        },
+      })
+    );
+
+    const client = await loadClient();
+    const instances = await client.listInstances('  ');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://broker.example/broker/session/status');
+    expect(init?.method).toBe('GET');
+    expect((init?.headers as Headers).get('x-api-key')).toBe('broker-key');
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0]).toMatchObject({
+      id: 'instance-2',
+      tenantId: 'tenant-from-broker',
+      status: 'disconnected',
+      connected: false,
     });
   });
 

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -681,8 +681,11 @@ class WhatsAppBrokerClient {
 
     let lastError: unknown;
 
-    const tenantApiKey = typeof tenantId === 'string' ? tenantId.trim() : '';
-    const apiKey = tenantApiKey.length > 0 ? tenantApiKey : undefined;
+    const normalizedTenantId =
+      typeof tenantId === 'string' ? tenantId.trim() : '';
+    const requestOptions: BrokerRequestOptions = normalizedTenantId.length > 0
+      ? { searchParams: { tenantId: normalizedTenantId } }
+      : {};
 
     for (let index = 0; index < candidatePaths.length; index += 1) {
       const path = candidatePaths[index];
@@ -693,9 +696,7 @@ class WhatsAppBrokerClient {
           {
             method: 'GET',
           },
-          {
-            apiKey,
-          }
+          requestOptions
         );
 
         const session = this.findSessionPayload(response);


### PR DESCRIPTION
## Summary
- update `listInstances` to reuse the broker API key while sending the tenant id as a query parameter when present
- adjust WhatsApp broker client tests to assert the broker credential header and cover the default listing scenario

## Testing
- pnpm --filter @ticketz/api test *(fails: existing auth middleware fallback tests already failing in main)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4f88cdec8332a31533b30f8285ec