### PR TITLE
Adjust WhatsApp polling backoff logic

### DIFF
--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -85,6 +85,10 @@ const handleResponse = async (response) => {
     error.status = response.status;
     error.statusText = response.statusText;
     error.payload = payload;
+    const retryAfterHeader = response.headers.get('Retry-After');
+    if (retryAfterHeader) {
+      error.retryAfter = retryAfterHeader;
+    }
     throw error;
   }
   return payload;


### PR DESCRIPTION
## Summary
- replace the fixed WhatsApp polling interval with timeout-based scheduling that uses a default delay, handles cooldowns on HTTP 429 responses, and keeps track of in-flight requests
- return polling results from `loadInstances` and parse `Retry-After` headers so the next poll can honor server-provided backoff windows
- propagate the `Retry-After` header through `safeFetch` error objects to support dynamic client retries

## Testing
- pnpm --filter web lint *(fails: `_timestamp` is defined but never used in Dashboard.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd593a876483329e0bb76d3fd3c5b6