### PR TITLE
feat(web): generate whatsapp qr data urls

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
     "next-themes": "^0.4.6",
+    "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-day-picker": "8.10.1",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.1)(react@19.1.1)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.1.0
         version: 19.1.1


### PR DESCRIPTION
## Summary
- add the qrcode library to the web app so the bundler ships a QR generator
- generate WhatsApp QR images asynchronously from Baileys-style payloads and show a spinner until ready
- guard polling state while QR images are being generated to avoid race conditions

## Testing
- pnpm --filter web lint *(fails: pre-existing Dashboard.jsx no-unused-vars error)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5f444c1c8332b0353c0ac3d1adb7