### PR TITLE
Add lead allocation API endpoints

### DIFF
--- a/apps/api/src/data/lead-allocation-store.ts
+++ b/apps/api/src/data/lead-allocation-store.ts
@@ -19,13 +19,17 @@ export interface AllocationResult {
 
 export const listAllocations = async (
   tenantId: string,
-  agreementId?: string,
-  campaignId?: string
+  options: {
+    agreementId?: string;
+    campaignId?: string;
+    statuses?: LeadAllocationStatus[];
+  } = {}
 ): Promise<LeadAllocation[]> => {
   return listPersistedAllocations({
     tenantId,
-    agreementId,
-    campaignId,
+    agreementId: options.agreementId,
+    campaignId: options.campaignId,
+    statuses: options.statuses,
   });
 };
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -7,6 +7,7 @@ export {
   allocateBrokerLeads,
   listAllocations,
   updateAllocation,
+  resetAllocationStore,
   type LeadAllocationDto,
   type LeadAllocationStatus,
   type AllocationSummary,


### PR DESCRIPTION
## Summary
- expose lead allocation listing, creation, update, and export endpoints in the lead engine router with validation and CSV output
- allow allocation filters in the allocation data store and export the reset helper from the storage package
- cover the new endpoints with integration tests for allocation workflows and invalid filters

## Testing
- pnpm --filter @ticketz/api test *(fails: existing auth middleware fallback tests expect different Prisma lookup behaviour)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6f0bec3c8332a22d199d53519ec5