### PR TITLE
Fix WhatsApp instances loading without agreement

### DIFF
--- a/apps/web/src/components/WhatsAppConnect.jsx
+++ b/apps/web/src/components/WhatsAppConnect.jsx
@@ -664,10 +664,6 @@ const WhatsAppConnect = ({
   }, [isGeneratingQrImage]);
 
   useEffect(() => {
-    if (!selectedAgreement?.id) {
-      return undefined;
-    }
-
     if (!isAuthenticated) {
       return undefined;
     }
@@ -877,9 +873,6 @@ const WhatsAppConnect = ({
   };
 
   const loadInstances = async ({ connectResult: providedConnect, preferredInstanceId } = {}) => {
-    if (!selectedAgreement) {
-      return { success: false, skipped: true };
-    }
     const token = getAuthToken();
     setAuthTokenState(token);
     setLoadingInstances(true);
@@ -988,9 +981,7 @@ const WhatsAppConnect = ({
       if (token) {
         setSessionActive(true);
         setErrorMessage(null);
-        if (selectedAgreement) {
-          void loadInstancesRef.current?.();
-        }
+        void loadInstancesRef.current?.();
       } else if (!sessionActiveRef.current) {
         enforceAuthPrompt();
       }


### PR DESCRIPTION
## Summary
- always refresh WhatsApp instance list even when no agreement is selected
- trigger instance refresh whenever the auth token becomes available

## Testing
- pnpm --filter web lint *(fails: existing lint error about unused variable in Dashboard.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dd74724ce88332a55e5452181fe644