### PR TITLE
Fix stylesheet import order for font loading

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <title>LeadEngine - Oportunidades Reais</title>
   </head>
   <body>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,3 +1,2 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';


### PR DESCRIPTION
## Summary
- load the Inter font through link tags in the HTML head instead of a CSS import
- keep the Tailwind and animation CSS imports at the top of the main stylesheet to satisfy the browser requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd7ae95db4833297c49bb20e62ab21