### PR TITLE
Normalize CORS origin handling

### DIFF
--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -74,3 +74,24 @@ describe('root availability handlers', () => {
     }
   });
 });
+
+describe('CORS configuration', () => {
+  it('allows equivalent origins with trailing slash', async () => {
+    const { server, url } = await startServer();
+
+    try {
+      const origin = 'https://leadengine-corban.onrender.com/';
+      const response = await fetch(`${url}/`, {
+        method: 'GET',
+        headers: {
+          Origin: origin,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('access-control-allow-origin')).toBe(origin);
+    } finally {
+      await stopServer(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- normalize configured CORS origins before storing in the allowlist
- ensure origin checks run against normalized values in the CORS callback
- add a regression test that accepts origins with trailing slashes

## Testing
- pnpm --filter @ticketz/api test -- src/server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd7e00432083329f2e383ce9b81506