### PR TITLE
Handle storage errors when listing lead allocations

### DIFF
--- a/apps/api/src/data/lead-allocation-store.ts
+++ b/apps/api/src/data/lead-allocation-store.ts
@@ -7,6 +7,7 @@ import {
   type LeadAllocationDto,
   type LeadAllocationStatus,
 } from '@ticketz/storage';
+import { logger } from '../config/logger';
 
 export type { LeadAllocationStatus };
 
@@ -17,6 +18,85 @@ export interface AllocationResult {
   summary: AllocationSummary;
 }
 
+type ErrorWithOptionalCode = { code?: unknown; message?: unknown } | Error;
+
+const getErrorCode = (error: unknown): string | undefined => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as ErrorWithOptionalCode).code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+
+  return undefined;
+};
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as ErrorWithOptionalCode).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+
+  return String(error);
+};
+
+const STORAGE_INIT_ERROR_CODES = new Set([
+  'STORAGE_NOT_INITIALIZED',
+  'ERR_STORAGE_NOT_INITIALIZED',
+]);
+
+const STORAGE_INIT_ERROR_MESSAGES = [
+  'storage not initialized',
+  'armazenamento não inicializado',
+];
+
+export const isStorageInitializationError = (error: unknown): boolean => {
+  const code = getErrorCode(error)?.toUpperCase();
+  if (code && STORAGE_INIT_ERROR_CODES.has(code)) {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+  return STORAGE_INIT_ERROR_MESSAGES.some((knownMessage) =>
+    message.includes(knownMessage)
+  );
+};
+
+const STORAGE_UNAVAILABLE_CODES = new Set([
+  'STORAGE_UNAVAILABLE',
+  'ERR_STORAGE_UNAVAILABLE',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+const STORAGE_UNAVAILABLE_MESSAGES = [
+  'storage unavailable',
+  'falha ao acessar o armazenamento',
+  'conexão recusada',
+  'connection refused',
+];
+
+export const isStorageUnavailableError = (error: unknown): boolean => {
+  const code = getErrorCode(error)?.toUpperCase();
+  if (code && STORAGE_UNAVAILABLE_CODES.has(code)) {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+  return STORAGE_UNAVAILABLE_MESSAGES.some((knownMessage) =>
+    message.includes(knownMessage)
+  );
+};
+
 export const listAllocations = async (
   tenantId: string,
   options: {
@@ -25,12 +105,27 @@ export const listAllocations = async (
     statuses?: LeadAllocationStatus[];
   } = {}
 ): Promise<LeadAllocation[]> => {
-  return listPersistedAllocations({
-    tenantId,
-    agreementId: options.agreementId,
-    campaignId: options.campaignId,
-    statuses: options.statuses,
-  });
+  try {
+    return await listPersistedAllocations({
+      tenantId,
+      agreementId: options.agreementId,
+      campaignId: options.campaignId,
+      statuses: options.statuses,
+    });
+  } catch (error) {
+    if (isStorageInitializationError(error)) {
+      logger.warn('[LeadAllocationStore] Storage not initialized when listing allocations', {
+        tenantId,
+        agreementId: options.agreementId,
+        campaignId: options.campaignId,
+        statuses: options.statuses,
+        error,
+      });
+      return [];
+    }
+
+    throw error;
+  }
 };
 
 export const addAllocations = async (


### PR DESCRIPTION
## Summary
- add helpers to detect storage initialization and availability issues in the lead allocation store
- return empty responses or service unavailable errors when GET /api/lead-engine/allocations encounters known storage failures
- cover the storage initialization scenario with an automated route test

## Testing
- pnpm --filter @ticketz/api test -- lead-engine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd7e03fef08332b85c186c05441c3e