### PR TITLE
Fix CORS handling and align WhatsApp routes

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -384,6 +384,10 @@ export async function getUserById(userId: string): Promise<AuthenticatedUser | n
  * Middleware de autenticação JWT
  */
 export const authMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+  if (req.method === 'OPTIONS') {
+    return next();
+  }
+
   try {
     if (AUTH_DISABLED_FOR_MVP) {
       req.user = buildMvpBypassUser();
@@ -580,6 +584,10 @@ export const requireRole = (requiredRole: 'ADMIN' | 'SUPERVISOR') => {
  * Middleware para verificar se o usuário pertence ao tenant
  */
 export const requireTenant = (req: Request, res: Response, next: NextFunction) => {
+  if (req.method === 'OPTIONS') {
+    return next();
+  }
+
   if (!req.user && AUTH_DISABLED_FOR_MVP) {
     req.user = buildMvpBypassUser();
   }

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -425,9 +425,13 @@ router.post(
 // POST /api/integrations/whatsapp/instances/connect - Connect the default WhatsApp instance
 router.post(
   '/whatsapp/instances/connect',
+  body('instanceId').optional().isString().trim().notEmpty(),
+  validateRequest,
   requireTenant,
-  asyncHandler(async (_req: Request, res: Response) => {
-    const instanceId = resolveDefaultInstanceId();
+  asyncHandler(async (req: Request, res: Response) => {
+    const requestedInstanceId =
+      typeof req.body?.instanceId === 'string' ? req.body.instanceId.trim() : '';
+    const instanceId = requestedInstanceId || resolveDefaultInstanceId();
 
     try {
       await whatsappBrokerClient.connectInstance(instanceId);
@@ -435,7 +439,10 @@ router.post(
 
       res.json({
         success: true,
-        data: normalizeInstanceStatusResponse(status),
+        data: {
+          instanceId,
+          ...normalizeInstanceStatusResponse(status),
+        },
       });
     } catch (error) {
       if (respondWhatsAppNotConfigured(res, error)) {
@@ -479,10 +486,13 @@ router.post(
 router.post(
   '/whatsapp/instances/disconnect',
   body('wipe').optional().isBoolean(),
+  body('instanceId').optional().isString().trim().notEmpty(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {
-    const instanceId = resolveDefaultInstanceId();
+    const requestedInstanceId =
+      typeof req.body?.instanceId === 'string' ? req.body.instanceId.trim() : '';
+    const instanceId = requestedInstanceId || resolveDefaultInstanceId();
     const wipe = typeof req.body?.wipe === 'boolean' ? req.body.wipe : undefined;
     const disconnectOptions = wipe === undefined ? undefined : { wipe };
 
@@ -492,7 +502,10 @@ router.post(
 
       res.json({
         success: true,
-        data: normalizeInstanceStatusResponse(status),
+        data: {
+          instanceId,
+          ...normalizeInstanceStatusResponse(status),
+        },
       });
     } catch (error) {
       if (respondWhatsAppNotConfigured(res, error)) {
@@ -531,16 +544,23 @@ router.get(
 // GET /api/integrations/whatsapp/instances/qr - Fetch QR code for the default WhatsApp instance
 router.get(
   '/whatsapp/instances/qr',
+  query('instanceId').optional().isString().trim().notEmpty(),
+  validateRequest,
   requireTenant,
-  asyncHandler(async (_req: Request, res: Response) => {
-    const instanceId = resolveDefaultInstanceId();
+  asyncHandler(async (req: Request, res: Response) => {
+    const requestedInstanceId =
+      typeof req.query.instanceId === 'string' ? req.query.instanceId.trim() : '';
+    const instanceId = requestedInstanceId || resolveDefaultInstanceId();
 
     try {
       const qrCode = await whatsappBrokerClient.getQrCode(instanceId);
 
       res.json({
         success: true,
-        data: normalizeQr(qrCode),
+        data: {
+          instanceId,
+          ...normalizeQr(qrCode),
+        },
       });
     } catch (error) {
       if (respondWhatsAppNotConfigured(res, error)) {

--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -4,6 +4,7 @@ import {
   onAuthTokenChange,
   onTenantIdChange,
 } from './auth.js';
+import { computeBackoffDelay, parseRetryAfterMs } from './rate-limit.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
 
@@ -99,39 +100,140 @@ const withDefaultHeaders = (extraHeaders = {}) => ({
   ...extraHeaders,
 });
 
-const safeFetch = async (path, init = {}) => {
+const sleep = (ms) =>
+  ms > 0
+    ? new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      })
+    : Promise.resolve();
+
+const RATE_LIMIT_BASE_DELAY_MS = 2000;
+const RATE_LIMIT_MAX_DELAY_MS = 30000;
+
+const rateLimitBuckets = new Map();
+
+const resolveRateLimitKey = (path, customKey) => {
+  if (typeof customKey === 'string' && customKey.trim().length > 0) {
+    return customKey.trim();
+  }
+
+  if (!path) {
+    return '::root';
+  }
+
   try {
-    const response = await fetch(buildUrl(path), init);
-    return await handleResponse(response);
+    const url = path.startsWith('http')
+      ? new URL(path)
+      : new URL(path.startsWith('/') ? path : `/${path}`, API_BASE_URL || 'http://localhost');
+    return url.pathname || path;
   } catch (error) {
-    if (error instanceof TypeError) {
-      throw new Error('Falha de rede ao comunicar com a API');
-    }
-    throw error;
+    return path.startsWith('/') ? path : `/${path}`;
   }
 };
 
-export const apiGet = async (path, options = {}) =>
-  safeFetch(path, {
-    headers: withDefaultHeaders(),
-    credentials: 'include',
-    ...options,
-  });
+const runWithRateLimit = async (key, task) => {
+  if (!rateLimitBuckets.has(key)) {
+    rateLimitBuckets.set(key, {
+      queue: Promise.resolve(),
+      nextAvailableAt: 0,
+      attempts: 0,
+    });
+  }
 
-export const apiPost = async (path, body, options = {}) =>
-  safeFetch(path, {
+  const bucket = rateLimitBuckets.get(key);
+
+  const execute = async () => {
+    const waitMs = bucket.nextAvailableAt - Date.now();
+    if (waitMs > 0) {
+      await sleep(waitMs);
+    }
+
+    try {
+      const result = await task();
+      bucket.nextAvailableAt = 0;
+      bucket.attempts = 0;
+      return result;
+    } catch (error) {
+      const status = error?.status ?? error?.statusCode ?? error?.response?.status;
+      if (typeof status === 'number' && (status === 429 || status === 503 || status >= 500)) {
+        const retryAfterMs = parseRetryAfterMs(
+          error?.retryAfter ?? error?.payload?.retryAfter ?? error?.rateLimitDelayMs ?? null
+        );
+        const attempt = bucket.attempts + 1;
+        bucket.attempts = attempt;
+        const waitDuration =
+          retryAfterMs !== null
+            ? retryAfterMs
+            : computeBackoffDelay(attempt, {
+                baseMs: RATE_LIMIT_BASE_DELAY_MS,
+                maxMs: RATE_LIMIT_MAX_DELAY_MS,
+              });
+        bucket.nextAvailableAt = Date.now() + waitDuration;
+        error.rateLimitDelayMs = waitDuration;
+      } else {
+        bucket.nextAvailableAt = 0;
+        bucket.attempts = 0;
+      }
+
+      throw error;
+    }
+  };
+
+  bucket.queue = bucket.queue.then(execute, execute);
+  return bucket.queue;
+};
+
+const safeFetch = async (path, init = {}) => {
+  const { rateLimitKey, ...fetchInit } = init;
+  const key = resolveRateLimitKey(path, rateLimitKey);
+
+  return runWithRateLimit(key, async () => {
+    try {
+      const response = await fetch(buildUrl(path), fetchInit);
+      return await handleResponse(response);
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new Error('Falha de rede ao comunicar com a API');
+      }
+      throw error;
+    }
+  });
+};
+
+const prepareOptions = (options = {}) => {
+  const { rateLimitKey, headers: extraHeaders, ...rest } = options;
+  const headers = withDefaultHeaders(extraHeaders);
+  return { ...rest, rateLimitKey, headers };
+};
+
+export const apiGet = async (path, options = {}) => {
+  const prepared = prepareOptions(options);
+  return safeFetch(path, {
+    ...prepared,
+    credentials: prepared.credentials ?? 'include',
+  });
+};
+
+export const apiPost = async (path, body, options = {}) => {
+  const prepared = prepareOptions(options);
+  const headers = { ...prepared.headers, 'Content-Type': 'application/json' };
+  return safeFetch(path, {
+    ...prepared,
     method: 'POST',
-    headers: withDefaultHeaders({ 'Content-Type': 'application/json' }),
+    headers,
     body: JSON.stringify(body),
-    credentials: 'include',
-    ...options,
+    credentials: prepared.credentials ?? 'include',
   });
+};
 
-export const apiPatch = async (path, body, options = {}) =>
-  safeFetch(path, {
+export const apiPatch = async (path, body, options = {}) => {
+  const prepared = prepareOptions(options);
+  const headers = { ...prepared.headers, 'Content-Type': 'application/json' };
+  return safeFetch(path, {
+    ...prepared,
     method: 'PATCH',
-    headers: withDefaultHeaders({ 'Content-Type': 'application/json' }),
+    headers,
     body: JSON.stringify(body),
-    credentials: 'include',
-    ...options,
+    credentials: prepared.credentials ?? 'include',
   });
+};

--- a/apps/web/src/lib/rate-limit.js
+++ b/apps/web/src/lib/rate-limit.js
@@ -1,0 +1,48 @@
+const DEFAULT_BASE_DELAY_MS = 2000;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+export const parseRetryAfterMs = (retryAfter) => {
+  if (retryAfter === null || retryAfter === undefined) {
+    return null;
+  }
+
+  if (typeof retryAfter === 'number' && Number.isFinite(retryAfter)) {
+    const asMilliseconds = retryAfter > 1000 ? retryAfter : retryAfter * 1000;
+    return Math.max(0, Math.round(asMilliseconds));
+  }
+
+  if (typeof retryAfter === 'string') {
+    const trimmed = retryAfter.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const numericCandidate = Number(trimmed);
+    if (Number.isFinite(numericCandidate)) {
+      const asMilliseconds = numericCandidate > 1000 ? numericCandidate : numericCandidate * 1000;
+      return Math.max(0, Math.round(asMilliseconds));
+    }
+
+    const parsedDate = Date.parse(trimmed);
+    if (!Number.isNaN(parsedDate)) {
+      const diff = parsedDate - Date.now();
+      return diff > 0 ? diff : 0;
+    }
+  }
+
+  return null;
+};
+
+export const computeBackoffDelay = (attempt = 1, { baseMs = DEFAULT_BASE_DELAY_MS, maxMs = DEFAULT_MAX_DELAY_MS } = {}) => {
+  const normalizedAttempt = Math.max(1, Number.isFinite(attempt) ? attempt : 1);
+  const base = Math.max(1, baseMs);
+  const max = Math.max(base, maxMs);
+  const exponent = normalizedAttempt - 1;
+  const delay = base * Math.pow(2, exponent);
+  return Math.min(max, delay);
+};
+
+export const RATE_LIMIT_DEFAULTS = {
+  baseDelayMs: DEFAULT_BASE_DELAY_MS,
+  maxDelayMs: DEFAULT_MAX_DELAY_MS,
+};


### PR DESCRIPTION
## Summary
- harden the API bootstrap so OPTIONS requests bypass auth and rate-limit responses emit Retry-After headers
- align WhatsApp integration routes with optional instance identifiers while keeping default instance support
- propagate upstream Lead Engine errors with better metadata and add shared front-end rate limit backoff utilities

## Testing
- pnpm --filter api build
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68dd83513aec83328c97c6c52576ca60