### PR TITLE
feat: persist WhatsApp instances and stabilise integration tests

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -30,6 +30,7 @@ describe('authMiddleware fallback behaviour', () => {
     vi.restoreAllMocks();
     vi.resetModules();
     process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+    process.env.AUTH_DISABLE_FOR_MVP = 'false';
   });
 
   afterEach(() => {

--- a/apps/api/src/routes/campaigns.ts
+++ b/apps/api/src/routes/campaigns.ts
@@ -1,0 +1,213 @@
+import { Router, type Request, type Response } from 'express';
+import { body, param, query } from 'express-validator';
+import { Prisma } from '@prisma/client';
+
+import { asyncHandler } from '../middleware/error-handler';
+import { requireTenant } from '../middleware/auth';
+import { validateRequest } from '../middleware/validation';
+import { prisma } from '../lib/prisma';
+
+const router = Router();
+
+const normalizeStatus = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (['active', 'paused', 'archived'].includes(normalized)) {
+    return normalized;
+  }
+
+  return null;
+};
+
+const respondNotFound = (res: Response): void => {
+  res.status(404).json({
+    success: false,
+    error: {
+      code: 'CAMPAIGN_NOT_FOUND',
+      message: 'Campanha não encontrada.',
+    },
+  });
+};
+
+router.post(
+  '/',
+  body('agreementId').isString().trim().isLength({ min: 1 }),
+  body('agreementName').isString().trim().isLength({ min: 1 }),
+  body('instanceId').isString().trim().isLength({ min: 1 }),
+  body('name').optional().isString().trim().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const tenantId = req.user!.tenantId;
+    const { agreementId, agreementName, instanceId } = req.body as {
+      agreementId: string;
+      agreementName: string;
+      instanceId: string;
+      name?: string;
+    };
+    const providedName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+
+    const instance = await prisma.whatsAppInstance.findUnique({ where: { id: instanceId } });
+    if (!instance || instance.tenantId !== tenantId) {
+      res.status(404).json({
+        success: false,
+        error: {
+          code: 'INSTANCE_NOT_FOUND',
+          message: 'Instância WhatsApp não encontrada para o tenant.',
+        },
+      });
+      return;
+    }
+
+    const normalizedName = providedName || `${agreementName.trim()} • ${instanceId}`;
+
+    const existingActive = await prisma.campaign.findFirst({
+      where: {
+        tenantId,
+        agreementId: agreementId.trim(),
+        status: 'active',
+      },
+    });
+
+    if (existingActive) {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'CAMPAIGN_ALREADY_ACTIVE',
+          message: 'Já existe uma campanha ativa para este convênio.',
+        },
+      });
+      return;
+    }
+
+    const campaign = await prisma.campaign.create({
+      data: {
+        tenantId,
+        name: normalizedName,
+        agreementId: agreementId.trim(),
+        agreementName: agreementName.trim(),
+        whatsappInstanceId: instance.id,
+        status: 'active',
+      },
+    });
+
+    res.status(201).json({
+      success: true,
+      data: campaign,
+    });
+  })
+);
+
+router.get(
+  '/',
+  query('status').optional(),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const tenantId = req.user!.tenantId;
+    const rawStatus = req.query.status;
+
+    const statuses = Array.isArray(rawStatus)
+      ? rawStatus
+      : rawStatus !== undefined
+        ? [rawStatus]
+        : [];
+
+    const normalizedStatuses = statuses
+      .map((status) => normalizeStatus(status))
+      .filter((status): status is string => Boolean(status));
+
+    const campaigns = await prisma.campaign.findMany({
+      where: {
+        tenantId,
+        ...(normalizedStatuses.length > 0 ? { status: { in: normalizedStatuses } } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    res.json({
+      success: true,
+      data: campaigns,
+    });
+  })
+);
+
+router.patch(
+  '/:id',
+  param('id').isString().trim().isLength({ min: 1 }),
+  body('name').optional().isString().trim().isLength({ min: 1 }),
+  body('status').optional().isString().trim().isLength({ min: 1 }),
+  validateRequest,
+  requireTenant,
+  asyncHandler(async (req: Request, res: Response) => {
+    const tenantId = req.user!.tenantId;
+    const campaignId = req.params.id;
+    const rawStatus = normalizeStatus(req.body?.status);
+    const rawName = typeof req.body?.name === 'string' ? req.body.name.trim() : undefined;
+
+    const campaign = await prisma.campaign.findFirst({
+      where: { id: campaignId, tenantId },
+    });
+
+    if (!campaign) {
+      respondNotFound(res);
+      return;
+    }
+
+    const updates: Prisma.CampaignUpdateInput = {};
+
+    if (rawName) {
+      updates.name = rawName;
+    }
+
+    if (rawStatus) {
+      if (rawStatus === 'active') {
+        const activeConflict = await prisma.campaign.findFirst({
+          where: {
+            tenantId,
+            agreementId: campaign.agreementId,
+            status: 'active',
+            NOT: { id: campaign.id },
+          },
+        });
+
+        if (activeConflict) {
+          res.status(409).json({
+            success: false,
+            error: {
+              code: 'CAMPAIGN_ALREADY_ACTIVE',
+              message: 'Já existe uma campanha ativa para este convênio.',
+            },
+          });
+          return;
+        }
+      }
+
+      updates.status = rawStatus;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res.json({ success: true, data: campaign });
+      return;
+    }
+
+    const updated = await prisma.campaign.update({
+      where: { id: campaign.id },
+      data: updates,
+    });
+
+    res.json({
+      success: true,
+      data: updated,
+    });
+  })
+);
+
+export const campaignsRouter = router;

--- a/apps/api/src/routes/lead-engine.test.ts
+++ b/apps/api/src/routes/lead-engine.test.ts
@@ -366,7 +366,7 @@ describe('Lead Engine allocations routes', () => {
     });
 
     try {
-      const response = await fetch(`${url}/api/lead-engine/allocations`, {
+      const response = await fetch(`${url}/api/lead-engine/allocations?campaignId=campaign-123`, {
         headers: {
           'x-tenant-id': 'tenant-alloc',
         },

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -13,8 +13,18 @@ vi.mock('./routes/webhooks', () => ({
 }));
 vi.mock('./routes/integrations', () => ({ integrationsRouter: express.Router() }));
 vi.mock('./routes/lead-engine', () => ({ leadEngineRouter: express.Router() }));
-vi.mock('./middleware/auth', () => ({ authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next() }));
-vi.mock('./middleware/error-handler', () => ({ errorHandler: (_err: unknown, _req: unknown, _res: unknown, next: () => void) => next() }));
+vi.mock('./middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireTenant: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock('./middleware/error-handler', () => ({
+  errorHandler: (_err: unknown, _req: unknown, _res: unknown, next: () => void) => next(),
+  asyncHandler:
+    <T extends (...args: unknown[]) => unknown>(handler: T) =>
+    ((req: unknown, res: unknown, next: () => void) => {
+      Promise.resolve(handler(req, res, next)).catch(next);
+    }),
+}));
 
 import { app } from './server';
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -20,6 +20,7 @@ import { leadEngineRouter } from './routes/lead-engine';
 import { logger } from './config/logger';
 import { registerSocketServer } from './lib/socket-registry';
 import { getWhatsAppEventPollerMetrics, whatsappEventPoller } from './workers/whatsapp-event-poller';
+import { campaignsRouter } from './routes/campaigns';
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -228,6 +229,7 @@ app.use('/api/tickets', authMiddleware, ticketsRouter);
 app.use('/api/leads', authMiddleware, leadsRouter);
 app.use('/api/contacts', authMiddleware, contactsRouter);
 app.use('/api/integrations', authMiddleware, integrationsRouter);
+app.use('/api/campaigns', authMiddleware, campaignsRouter);
 
 // Socket.IO para tempo real
 io.use((socket, next) => {

--- a/apps/api/src/services/whatsapp-broker-client.test.ts
+++ b/apps/api/src/services/whatsapp-broker-client.test.ts
@@ -59,7 +59,12 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     expect(url).toBe('https://broker.example/broker/session/connect');
     expect(init?.method).toBe('POST');
     const body = JSON.parse(String(init?.body));
-    expect(body).toEqual({ sessionId: 'session-1', webhookUrl: 'https://hooks.example', forceReopen: true });
+    expect(body).toEqual({
+      sessionId: 'session-1',
+      instanceId: 'session-1',
+      webhookUrl: 'https://hooks.example',
+      forceReopen: true,
+    });
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('broker-key');
     expect(headers.get('content-type')).toBe('application/json');
@@ -147,6 +152,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     const body = JSON.parse(String(init?.body));
     expect(body).toEqual({
       sessionId: 'session-1',
+      instanceId: 'session-1',
       to: '5511987654321',
       message: 'Hello',
       type: 'text',
@@ -172,6 +178,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     const body = JSON.parse(String(init?.body));
     expect(body).toEqual({
       sessionId: 'session-1',
+      instanceId: 'session-1',
       to: '5511987654321',
       question: 'Qual opção?',
       options: ['A', 'B', 'C'],
@@ -195,7 +202,9 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('https://broker.example/broker/session/status?sessionId=session-qr');
+    expect(url).toBe(
+      'https://broker.example/broker/session/status?sessionId=session-qr&instanceId=session-qr'
+    );
     expect(init?.method).toBe('GET');
     const headers = init?.headers as Headers;
     expect(headers.get('x-api-key')).toBe('broker-key');
@@ -227,9 +236,13 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const [statusUrl] = fetchMock.mock.calls[0];
-    expect(statusUrl).toBe('https://broker.example/broker/session/status?sessionId=session-qr');
+    expect(statusUrl).toBe(
+      'https://broker.example/broker/session/status?sessionId=session-qr&instanceId=session-qr'
+    );
     const [qrUrl] = fetchMock.mock.calls[1];
-    expect(qrUrl).toBe('https://broker.example/broker/session/qr?sessionId=session-qr');
+    expect(qrUrl).toBe(
+      'https://broker.example/broker/session/qr?sessionId=session-qr&instanceId=session-qr'
+    );
     expect(result).toEqual({
       qr: 'data:image/png;base64,REAL_QR',
       qrCode: 'data:image/png;base64,REAL_QR',
@@ -266,7 +279,7 @@ describe('WhatsAppBrokerClient (minimal broker)', () => {
     const result = await client.getStatus('session-status');
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://broker.example/broker/session/status?sessionId=session-status',
+      'https://broker.example/broker/session/status?sessionId=session-status&instanceId=session-status',
       expect.objectContaining({ method: 'GET' })
     );
     expect(result).toEqual({

--- a/apps/api/src/workers/whatsapp-event-poller.test.ts
+++ b/apps/api/src/workers/whatsapp-event-poller.test.ts
@@ -95,8 +95,8 @@ describe('WhatsApp event poller', () => {
     });
     expect(processedIntegrationEventCreateMany).toHaveBeenCalledWith({
       data: expect.arrayContaining([
-        expect.objectContaining({ id: 'evt-1', type: 'MESSAGE_INBOUND' }),
-        expect.objectContaining({ id: 'evt-2', type: 'MESSAGE_OUTBOUND' }),
+        expect.objectContaining({ id: 'evt-1', payload: expect.anything() }),
+        expect.objectContaining({ id: 'evt-2', payload: expect.anything() }),
       ]),
       skipDuplicates: true,
     });

--- a/apps/api/src/workers/whatsapp-event-poller.ts
+++ b/apps/api/src/workers/whatsapp-event-poller.ts
@@ -287,10 +287,8 @@ class WhatsAppEventPoller {
         data: freshEvents.map((event) => ({
           id: event.id,
           source: SOURCE_KEY,
-          type: event.type,
           cursor: event.cursor ?? this.cursor ?? null,
-          metadata: toJsonValue(event.payload ?? null),
-          expiresAt: new Date(Date.now() + PROCESSED_EVENT_TTL_MS),
+          payload: toJsonValue(event),
         } satisfies Prisma.ProcessedIntegrationEventCreateManyInput)),
         skipDuplicates: true,
       });
@@ -366,10 +364,7 @@ class WhatsAppEventPoller {
       const result = await prisma.processedIntegrationEvent.deleteMany({
         where: {
           source: SOURCE_KEY,
-          OR: [
-            { expiresAt: { lt: new Date() } },
-            { processedAt: { lt: threshold } },
-          ],
+          createdAt: { lt: threshold },
         },
       });
       if (result.count > 0) {

--- a/apps/api/src/workers/whatsapp-event-queue.ts
+++ b/apps/api/src/workers/whatsapp-event-queue.ts
@@ -9,6 +9,7 @@ export interface WhatsAppBrokerEvent {
   payload: unknown;
   tenantId?: string;
   sessionId?: string;
+  instanceId?: string;
   timestamp?: string;
   cursor?: string | null;
 }
@@ -19,6 +20,7 @@ interface NormalizedEventInput {
   payload?: unknown;
   tenantId?: unknown;
   sessionId?: unknown;
+  instanceId?: unknown;
   timestamp?: unknown;
   cursor?: unknown;
 }
@@ -82,6 +84,10 @@ export const normalizeWhatsAppBrokerEvent = (input: NormalizedEventInput): Whats
   const payload = 'payload' in input ? input.payload : null;
   const tenantId = typeof input.tenantId === 'string' && input.tenantId.trim().length > 0 ? input.tenantId.trim() : undefined;
   const sessionId = typeof input.sessionId === 'string' && input.sessionId.trim().length > 0 ? input.sessionId.trim() : undefined;
+  const instanceId =
+    typeof input.instanceId === 'string' && input.instanceId.trim().length > 0
+      ? input.instanceId.trim()
+      : undefined;
   const timestamp = typeof input.timestamp === 'string' && input.timestamp.trim().length > 0 ? input.timestamp.trim() : undefined;
   const cursor = typeof input.cursor === 'string' && input.cursor.trim().length > 0 ? input.cursor.trim() : null;
 
@@ -91,6 +97,7 @@ export const normalizeWhatsAppBrokerEvent = (input: NormalizedEventInput): Whats
     payload,
     tenantId,
     sessionId,
+    instanceId,
     timestamp,
     cursor,
   };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -216,26 +216,24 @@ model Lead {
 }
 
 model Campaign {
-  id             String         @id @default(cuid())
-  tenantId       String
-  name           String
-  description    String?
-  type           CampaignType
-  status         CampaignStatus @default(DRAFT)
-  startDate      DateTime?
-  endDate        DateTime?
-  budget         Float?
-  targetAudience Json           @default("{}")
-  content        Json           @default("{}")
-  settings       Json           @default("{}")
-  metrics        Json           @default("{}")
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
+  id                 String   @id @default(cuid())
+  tenantId           String
+  name               String
+  agreementId        String?
+  agreementName      String?
+  whatsappInstanceId String?
+  status             String   @default("active")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  metadata           Json?
 
   // Relations
-  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  leads  Lead[]
+  tenant            Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  leads             Lead[]
+  whatsappInstance  WhatsAppInstance? @relation(fields: [whatsappInstanceId], references: [id])
 
+  @@index([tenantId, status])
+  @@index([tenantId, agreementId])
   @@map("campaigns")
 }
 
@@ -267,16 +265,42 @@ model IntegrationState {
 }
 
 model ProcessedIntegrationEvent {
-  id          String   @id
-  source      String
-  type        String?
-  cursor      String?
-  metadata    Json?
-  processedAt DateTime @default(now())
-  expiresAt   DateTime?
+  id        String   @id
+  source    String
+  cursor    String?
+  payload   Json?
+  createdAt DateTime @default(now())
 
-  @@index([source, processedAt])
+  @@index([source, createdAt])
   @@map("processed_integration_events")
+}
+
+enum WhatsAppInstanceStatus {
+  disconnected
+  connecting
+  connected
+  error
+}
+
+model WhatsAppInstance {
+  id          String                   @id
+  tenantId    String
+  name        String
+  brokerId    String
+  phoneNumber String?
+  status      WhatsAppInstanceStatus   @default(disconnected)
+  connected   Boolean                  @default(false)
+  lastSeenAt  DateTime?
+  createdAt   DateTime                 @default(now())
+  updatedAt   DateTime                 @updatedAt
+  metadata    Json?
+
+  campaigns   Campaign[]
+
+  @@index([tenantId])
+  @@unique([tenantId, id])
+  @@unique([brokerId])
+  @@map("whatsapp_instances")
 }
 
 // ============================================================================
@@ -362,25 +386,6 @@ enum LeadSource {
   PARTNER
   IMPORT
   OTHER
-}
-
-enum CampaignType {
-  EMAIL
-  WHATSAPP
-  SMS
-  VOICE
-  SOCIAL
-  DISPLAY
-  SEARCH
-}
-
-enum CampaignStatus {
-  DRAFT
-  SCHEDULED
-  RUNNING
-  PAUSED
-  COMPLETED
-  CANCELLED
 }
 
 enum LeadActivityType {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -176,25 +176,45 @@ async function main() {
 
   console.log('✅ Contatos demo criados');
 
+  // Criar instância WhatsApp demo
+  const demoInstance = await prisma.whatsAppInstance.upsert({
+    where: { id: 'demo-whatsapp' },
+    update: {
+      tenantId: demoTenant.id,
+      name: 'WhatsApp Demo',
+      brokerId: 'demo-whatsapp',
+      status: 'connected',
+      connected: true,
+      metadata: {
+        note: 'Instância demo criada pelo seed',
+      },
+    },
+    create: {
+      id: 'demo-whatsapp',
+      tenantId: demoTenant.id,
+      name: 'WhatsApp Demo',
+      brokerId: 'demo-whatsapp',
+      status: 'connected',
+      connected: true,
+      metadata: {
+        note: 'Instância demo criada pelo seed',
+      },
+    },
+  });
+
+  console.log('✅ Instância WhatsApp demo criada:', demoInstance.name);
+
   // Criar campanha demo
   const demoCampaign = await prisma.campaign.create({
     data: {
       tenantId: demoTenant.id,
-      name: 'Campanha SAEC Goiânia',
-      description: 'Campanha de leads para SAEC Goiânia',
-      type: 'WHATSAPP',
-      status: 'RUNNING',
-      startDate: new Date(),
-      targetAudience: {
-        region: 'GO',
-        agreement: 'saec-goiania',
-      },
-      content: {
-        message: 'Olá! Temos uma proposta de crédito consignado para você.',
-      },
-      settings: {
-        autoAssign: true,
-        maxLeadsPerDay: 100,
+      name: 'ConsigTec Goiânia • demo-whatsapp',
+      agreementId: 'saec-goiania',
+      agreementName: 'Convênio SAEC Goiânia',
+      whatsappInstanceId: demoInstance.id,
+      status: 'active',
+      metadata: {
+        note: 'Campanha demo criada pelo seed',
       },
     },
   });


### PR DESCRIPTION
## Summary
- add Prisma models and seeding for persisted WhatsApp instances and campaigns
- expose campaign CRUD routes and update WhatsApp integrations to read/write Prisma state and instance-specific broker calls
- extend broker client and associated tests to carry instanceId metadata and harden integration/auth/server test scaffolding

## Testing
- pnpm -F api test

------
https://chatgpt.com/codex/tasks/task_e_68dd9226225483329350580c7865de41