### PR TITLE
feat: auto slug WhatsApp instances and expose QR png proxy

### DIFF
--- a/apps/api/src/routes/lead-engine.test.ts
+++ b/apps/api/src/routes/lead-engine.test.ts
@@ -133,6 +133,33 @@ describe('Lead Engine campaigns routes', () => {
     }
   });
 
+  it('creates a campaign using agreementName as alias for name', async () => {
+    const { server, url } = await startTestServer();
+
+    try {
+      const response = await fetch(`${url}/api/lead-engine/campaigns`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          agreementId: 'agreement-1',
+          instanceId: 'instance-1',
+          agreementName: 'Alias Campaign',
+        }),
+      });
+
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.name).toBe('Alias Campaign');
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
   it('lists campaigns filtered by agreement and status', async () => {
     const { server, url } = await startTestServer();
 


### PR DESCRIPTION
## Summary
- allow WhatsApp instance creation to auto-slug IDs per tenant and keep metadata in sync
- expose PNG QR code endpoints for specific and default WhatsApp instances with binary proxy tests
- support the `agreementName` alias when creating campaigns while keeping existing validations

## Testing
- pnpm --filter api test

------
https://chatgpt.com/codex/tasks/task_e_68ddb68708bc8332ae43c6b2aeeeff17