### PR TITLE
Ensure web env vars are test-friendly

### DIFF
--- a/apps/web/src/components/DemoAuthDialog.jsx
+++ b/apps/web/src/components/DemoAuthDialog.jsx
@@ -3,6 +3,7 @@ import { LogIn } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import { Label } from '@/components/ui/label.jsx';
+import { getEnvVar } from '@/lib/runtime-env.js';
 import {
   Dialog,
   DialogContent,
@@ -20,10 +21,10 @@ import {
   onTenantIdChange,
 } from '@/lib/auth.js';
 
-const defaultEmail = import.meta.env.VITE_DEMO_OPERATOR_EMAIL || '';
-const defaultPassword = import.meta.env.VITE_DEMO_OPERATOR_PASSWORD || '';
+const defaultEmail = getEnvVar('VITE_DEMO_OPERATOR_EMAIL', '');
+const defaultPassword = getEnvVar('VITE_DEMO_OPERATOR_PASSWORD', '');
 const fallbackTenant =
-  import.meta.env.VITE_DEMO_TENANT_ID || import.meta.env.VITE_API_TENANT_ID || import.meta.env.VITE_TENANT_ID || '';
+  getEnvVar('VITE_DEMO_TENANT_ID') || getEnvVar('VITE_API_TENANT_ID') || getEnvVar('VITE_TENANT_ID') || '';
 
 const initialTenant = () => getTenantId() || fallbackTenant;
 

--- a/apps/web/src/features/whatsapp-chat/__tests__/WhatsAppChatPage.test.jsx
+++ b/apps/web/src/features/whatsapp-chat/__tests__/WhatsAppChatPage.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+
+import WhatsAppChatPage from '../WhatsAppChatPage.jsx';
+
+vi.mock('../hooks/useWhatsAppChat.js', () => ({
+  default: vi.fn(),
+}));
+
+const createHookState = (overrides = {}) => ({
+  tickets: [],
+  ticketsMeta: { total: 0 },
+  ticketsLoading: false,
+  ticketsError: null,
+  ticketFilters: { status: ['OPEN', 'PENDING', 'ASSIGNED'], search: '' },
+  setTicketFilters: vi.fn(),
+  refreshTickets: vi.fn(),
+  selectTicket: vi.fn(),
+  selectedTicket: null,
+  selectedTicketId: null,
+  messages: [],
+  messagesMeta: { hasNext: false },
+  messagesLoading: false,
+  messagesError: null,
+  loadMoreMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  composerBusy: false,
+  contact: null,
+  lead: null,
+  leadBusy: false,
+  updateLead: vi.fn(),
+  appendNote: vi.fn(),
+  notesBusy: false,
+  notesFilter: 'all',
+  setNotesFilter: vi.fn(),
+  filteredNotes: [],
+  updateOutcome: vi.fn(),
+  outcomeBusy: false,
+  markTicketResolved: vi.fn(),
+  timeline: [],
+  realtime: { connected: false, connectionError: null },
+  ...overrides,
+});
+
+beforeEach(async () => {
+  const module = await import('../hooks/useWhatsAppChat.js');
+  module.default.mockReturnValue(createHookState());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('WhatsAppChatPage', () => {
+  it('renders ticket filters and placeholder message when no ticket selected', () => {
+    render(<WhatsAppChatPage tenantId="tenant-123" />);
+
+    expect(screen.getByPlaceholderText('Buscar por contato, assunto ou tag')).toBeInTheDocument();
+    expect(screen.getByText('Nenhum ticket encontrado com os filtros selecionados.')).toBeInTheDocument();
+    expect(screen.getByText('Selecione um ticket para visualizar a conversa.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -5,8 +5,12 @@ import {
   onTenantIdChange,
 } from './auth.js';
 import { computeBackoffDelay, parseRetryAfterMs } from './rate-limit.js';
+import { getEnvVar } from './runtime-env.js';
 
-export const API_BASE_URL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
+export const API_BASE_URL = (() => {
+  const rawUrl = getEnvVar('VITE_API_URL', '');
+  return typeof rawUrl === 'string' ? rawUrl.replace(/\/$/, '') : '';
+})();
 
 let persistedToken = getAuthToken();
 let persistedTenantId = getTenantId();
@@ -42,7 +46,7 @@ const baseHeaders = () => {
 
   if (!tenantId) {
     const envTenant =
-      import.meta.env.VITE_API_TENANT_ID ?? import.meta.env.VITE_TENANT_ID ?? undefined;
+      getEnvVar('VITE_API_TENANT_ID') ?? getEnvVar('VITE_TENANT_ID') ?? undefined;
     if (typeof envTenant === 'string') {
       const normalized = envTenant.trim();
       tenantId = normalized.length > 0 ? normalized : undefined;
@@ -57,7 +61,7 @@ const baseHeaders = () => {
   }
 
   const tokenCandidate =
-    persistedToken || import.meta.env.VITE_API_AUTH_TOKEN || import.meta.env.VITE_API_TOKEN;
+    persistedToken || getEnvVar('VITE_API_AUTH_TOKEN') || getEnvVar('VITE_API_TOKEN');
   const authHeader = prepareAuthorization(tokenCandidate);
   if (authHeader) {
     headers.Authorization = authHeader;

--- a/apps/web/src/lib/auth.js
+++ b/apps/web/src/lib/auth.js
@@ -1,4 +1,9 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
+import { getEnvVar } from './runtime-env.js';
+
+const API_BASE_URL = (() => {
+  const rawUrl = getEnvVar('VITE_API_URL', '');
+  return typeof rawUrl === 'string' ? rawUrl.replace(/\/$/, '') : '';
+})();
 
 const TOKEN_STORAGE_KEY = 'leadengine_auth_token';
 const TENANT_STORAGE_KEY = 'tenantId';

--- a/apps/web/src/lib/runtime-env.js
+++ b/apps/web/src/lib/runtime-env.js
@@ -1,0 +1,42 @@
+const getImportMetaEnv = () => {
+  try {
+    if (typeof import.meta !== 'undefined' && import.meta && typeof import.meta === 'object') {
+      return import.meta.env ?? {};
+    }
+  } catch (error) {
+    console.debug('Failed to access import.meta.env', error);
+  }
+  return {};
+};
+
+const getProcessEnv = () => {
+  if (typeof process !== 'undefined' && process && typeof process === 'object') {
+    return process.env ?? {};
+  }
+  return {};
+};
+
+export const getEnvVar = (key, fallback) => {
+  if (!key || typeof key !== 'string') {
+    return fallback;
+  }
+
+  const importMetaEnv = getImportMetaEnv();
+  if (Object.prototype.hasOwnProperty.call(importMetaEnv, key)) {
+    const value = importMetaEnv[key];
+    return value ?? fallback;
+  }
+
+  const processEnv = getProcessEnv();
+  if (Object.prototype.hasOwnProperty.call(processEnv, key)) {
+    const value = processEnv[key];
+    return value ?? fallback;
+  }
+
+  return fallback;
+};
+
+export const getRuntimeEnv = () => ({
+  ...getProcessEnv(),
+  ...getImportMetaEnv(),
+});


### PR DESCRIPTION
## Summary
- add a runtime environment helper that gracefully falls back when `import.meta.env` is unavailable
- update auth, API utilities, and the demo login dialog to use the new helper for env access
- stabilise the WhatsApp chat page test by mocking the hook via dynamic import

## Testing
- pnpm --filter web exec vitest run src/features/whatsapp-chat/__tests__/WhatsAppChatPage.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68df146901f083328b9f3305dda26d1a