### PR TITLE
Fix storage build tsconfig path resolution

### DIFF
--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -2,10 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "paths": {
-      "@ticketz/core": ["../core/src/index.ts"],
-      "@ticketz/core/*": ["../core/src/*"]
-    }
+    "rootDir": "../../"
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- remove the local path override from the storage build tsconfig and set the rootDir so module resolution stays within the workspace

## Testing
- pnpm -F @ticketz/storage build

------
https://chatgpt.com/codex/tasks/task_e_68e1550e99548332b9b880399416ff21