### PR TITLE
Fix storage build tsconfig path resolution

### DIFF
--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
+    "rootDir": "../../",
     "paths": {
-      "@ticketz/core": ["../core/src/index.ts"],
-      "@ticketz/core/*": ["../core/src/*"]
+      "@ticketz/core": ["./packages/core/src/index.ts"],
+      "@ticketz/core/*": ["./packages/core/src/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- update the storage build tsconfig to use workspace-relative path mappings and set the rootDir so module resolution stays within the workspace

## Testing
- pnpm -F @ticketz/storage build

------
https://chatgpt.com/codex/tasks/task_e_68e1550e99548332b9b880399416ff21