### PR TITLE
fix(storage): ensure declaration output stays in dist

### DIFF
--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "rootDir": "../../"
+    "paths": {
+      "@ticketz/core": ["../core/dist/index.d.ts"],
+      "@ticketz/core/*": ["../core/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- remove the tsconfig.build rootDir override so the package uses its src folder when emitting declarations
- redirect the @ticketz/core path alias to the compiled output to avoid pulling external sources into the build

## Testing
- pnpm -F @ticketz/core build
- pnpm -F @ticketz/storage build

------
https://chatgpt.com/codex/tasks/task_e_68e158e602648332a758c3ff431b2b96