### PR TITLE
chore: configure NodeNext module resolution

### DIFF
--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -6,6 +6,8 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- switch the workspace base TypeScript config to use NodeNext module settings
- ensure the integrations package explicitly compiles declarations with NodeNext resolution

## Testing
- pnpm --filter @ticketz/integrations build

------
https://chatgpt.com/codex/tasks/task_e_68e15c0fbcf883328499d824118f84b3