### PR TITLE
chore: align storage tsconfig build with core sources

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": false
+    "composite": true
   }
 }

--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -2,15 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "rootDir": "../../",
-    "paths": {
-
-      "@ticketz/core": ["./packages/core/src/index.ts"],
-      "@ticketz/core/*": ["./packages/core/src/*"]
-      "@ticketz/core": ["../core/dist/index.d.ts"],
-      "@ticketz/core/*": ["../core/dist/*"]
-
-    }
+    "rootDir": "../../"
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- simplify the storage build tsconfig to rely on the workspace base path aliases instead of the generated core dist files
- keep the TypeScript root at the workspace level for storage builds so cross-package imports resolve while turning off composite mode for tsup compatibility
- enable composite mode on the core build tsconfig so the package remains ready for project references

## Testing
- pnpm --filter @ticketz/storage build

------
https://chatgpt.com/codex/tasks/task_e_68e15bfebd908332a82f5a8eefbc7ddf