### PR TITLE
fix(core): align build config and docs for tsup

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -69,6 +69,16 @@ A    www         IP_DO_SERVIDOR
 
 ## 🚀 Deploy
 
+### ✅ Validação obrigatória dos pacotes
+
+Antes de iniciar qualquer estratégia de deploy, valide a geração dos artefatos do pacote core para evitar falhas de tipagem em produção:
+
+```bash
+pnpm --filter @ticketz/core build
+```
+
+Esse comando executa o bundle e recompila apenas as declarações TypeScript necessárias para o pacote, garantindo que os módulos `common`, `tickets` e `leads` estejam listados corretamente e prevenindo o erro `TS6307` durante o pipeline.
+
 ### 1. Deploy Automatizado
 
 Use o script de deploy incluído:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,12 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && rm -f tsconfig.build.tsbuildinfo && tsc --project tsconfig.build.json --emitDeclarationOnly",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
     "test:watch": "vitest --watch --passWithNoTests",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
   },
   "dependencies": {
     "date-fns": "^3.0.6",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,6 +1,33 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true
-  }
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "src/index.ts",
+    "src/common/types.ts",
+    "src/tickets/index.ts",
+    "src/tickets/types.ts",
+    "src/tickets/services.ts",
+    "src/leads/index.ts",
+    "src/leads/types.ts"
+  ],
+  "include": [
+    "src/index.ts",
+    "src/common/**/*.ts",
+    "src/tickets/**/*.ts",
+    "src/leads/**/*.ts"
+  ]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     'src/analytics/index.ts',
   ],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary
- replace the core build tsconfig with an explicit configuration that emits declarations from the common, tickets, and leads modules while switching to ESNext modules
- adjust the core build pipeline so tsup handles JavaScript bundles and tsc emits declarations, and ensure cleaning drops the incremental file
- document the new core build verification step in the deploy guide to prevent TS6307 during release pipelines

## Testing
- pnpm --filter @ticketz/core build
- pnpm --filter @ticketz/core type-check

------
https://chatgpt.com/codex/tasks/task_e_68e15f9b72b88332abb128f4f467990a