### PR TITLE
Fix integrations build failure on Render

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup && rm -f tsconfig.build.tsbuildinfo && tsc --project tsconfig.build.json --emitDeclarationOnly",
-    "build": "tsup && tsc --project tsconfig.build.json",
+    "build": "tsup && rm -f tsconfig.build.tsbuildinfo && tsc --project tsconfig.build.json",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
     "test:watch": "vitest --watch --passWithNoTests",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,7 +26,9 @@
       "@ticketz/storage": ["./packages/storage/src/index.ts"],
       "@ticketz/storage/*": ["./packages/storage/src/*"],
       "@ticketz/integrations": ["./packages/integrations/src/index.ts"],
-      "@ticketz/integrations/*": ["./packages/integrations/src/*"]
+      "@ticketz/integrations/*": ["./packages/integrations/src/*"],
+      "@whiskeysockets/baileys": ["./node_modules/@whiskeysockets/baileys/lib/index.d.ts"],
+      "@hapi/boom": ["./node_modules/@hapi/boom/lib/index.d.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the duplicate build script definition in `@ticketz/core` so the build performs a single clean `tsc` pass
- add explicit TypeScript path fallbacks for the Baileys and Boom packages to keep declaration generation stable in all environments

## Testing
- pnpm --filter @ticketz/integrations build
- pnpm --filter @ticketz/core build


------
https://chatgpt.com/codex/tasks/task_e_68e166127f448332a5f2996ae0e7f0b9