### PR TITLE
Align toolchain config and stabilize package builds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     {
       "files": ["packages/*/src/**/*.ts"],
       "rules": {
-        "@typescript-eslint/no-restricted-imports": [
+        "no-restricted-imports": [
           "error",
           {
             "patterns": ["**/packages/*/src/**"]
@@ -28,14 +28,4 @@
       }
     }
   ]
-    }
-  ],
-  "rules": {
-    "no-restricted-imports": [
-      "error",
-      {
-        "patterns": ["@ticketz/*/src/*"]
-      }
-    ]
-  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,58 +1,20 @@
 name: ci
-
-on:
-  push:
-  pull_request:
-
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-
-      - name: Enable corepack & pnpm
-        run: corepack enable && corepack prepare pnpm@9.12.3 --activate
-
+        with: { node-version: '20.x' }
+      - run: corepack enable && corepack prepare pnpm@9.12.3 --activate
       - uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: pnpm -w install --frozen-lockfile
-
-      - name: Build libraries (clean)
-        run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean
-
-      - name: Typecheck libraries
-        run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck
-
-      - name: Prisma generate
-        run: pnpm -w prisma generate --schema=prisma/schema.prisma
-
-      - name: Build API
-        run: pnpm -F @ticketz/api build
-  pull_request:
-  push:
-    branches: [main]
-
-jobs:
-  types_and_libs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Enable corepack
-        run: corepack enable && corepack prepare pnpm@9.12.3 --activate
-      - name: Install dependencies
-        run: pnpm -w install --frozen-lockfile
-      - name: Build libraries
-        run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean
-      - name: Type check libraries
-        run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck
+          restore-keys: pnpm-${{ runner.os }}-
+      - run: pnpm -w install --frozen-lockfile
+      - run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck
+      - run: pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean
+      - run: pnpm -w prisma generate --schema=prisma/schema.prisma
+      - run: pnpm -F @ticketz/api build

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -131,7 +131,7 @@ Caso utilize o Render.com para hospedar a API como serviço web, configure os co
 | Start Command | `./node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma && node apps/api/dist/server.js` |
 | Node version | Defina `NODE_VERSION=20` (ou use a configuração padrão do Render baseada no `package.json`) |
 
-> ℹ️ O script `build` da API executa `build:dependencies`, que por sua vez roda `build:clean` e `typecheck` nos pacotes `@ticketz/{core,storage,integrations}` **antes** do bundler (`tsup`). Dessa forma, os diretórios `dist` são gerados com declarações atualizadas e qualquer regressão de tipos falha cedo, antes do `node apps/api/dist/server.js`.
+> ℹ️ O script `build` da API executa `build:dependencies`, que por sua vez roda `typecheck` e `build:clean` (nessa ordem) nos pacotes `@ticketz/{core,storage,integrations}` **antes** do bundler (`tsup`). Dessa forma, os diretórios `dist` são gerados com declarações atualizadas e qualquer regressão de tipos falha cedo, antes do `node apps/api/dist/server.js`.
 
 > ⚠️ Se o **WhatsApp Broker** também estiver hospedado no Render, inclua/reveja as rotas permitidas para aceitar `POST /instances/:id/start` (ou o fallback `POST /instances/:id/request-pairing-code`). A API passa a utilizar esses endpoints para iniciar o pareamento e solicitar novos QR Codes; certifique-se de que o serviço do broker esteja atualizado para respondê-los.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,20 @@ corepack prepare pnpm@9.12.3 --activate
 pnpm -w install --frozen-lockfile
 ```
 
-### 3. Configure as Variáveis de Ambiente
+### 3. Valide as bibliotecas antes do build da API
+Sempre que for buildar ou subir a API, execute a sequência abaixo para garantir que os pacotes compartilhados estejam consistentes:
+
+```bash
+corepack enable && corepack prepare pnpm@9.12.3 --activate && pnpm -w install --frozen-lockfile
+pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck
+pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean
+pnpm -F @ticketz/api run db:generate
+pnpm -F @ticketz/api build
+```
+
+> 💡 A API já chama `build:dependencies` antes de `tsup`, mas manter a mesma ordem de comandos no seu ambiente garante que regressões de tipos ou builds quebrados sejam detectados antes de chegar à pipeline.
+
+### 4. Configure as Variáveis de Ambiente
 
 #### Backend (apps/api/.env)
 ```env
@@ -362,9 +375,12 @@ pnpm run dev          # Inicia todos os serviços
 pnpm run dev:api      # Apenas API
 pnpm run dev:web      # Apenas frontend
 
-# Build
-pnpm run build        # Build completo
-pnpm run build:api    # Build apenas API
+# Build (ordem recomendada)
+pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck
+pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean
+pnpm -F @ticketz/api run db:generate
+pnpm -F @ticketz/api build
+pnpm run build        # Build completo (segue as dependências internas)
 pnpm run build:web    # Build apenas frontend
 
 # Testes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "description": "API REST para o sistema Ticketz-LeadEngine",
   "main": "dist/server.js",
   "scripts": {
-    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean && pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck",
+    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck && pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean",
     "build": "pnpm run build:dependencies && pnpm run db:generate && tsup",
     "dev": "tsx watch src/server.ts",
     "prestart": "pnpm run build:dependencies && pnpm run db:generate",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,23 +4,20 @@
   "description": "Domínio e casos de uso do sistema Ticketz-LeadEngine",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
-    "build": "tsup && pnpm run build:types",
-    "build:clean": "tsup --clean && pnpm run build:types",
-    "build:types": "tsc -p tsconfig.build.json",
     "build": "tsup",
     "build:clean": "tsup --clean",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
     "test:watch": "vitest --watch --passWithNoTests",
-    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "clean": "rm -rf dist tsconfig.build.tsbuildinfo"
   },
   "dependencies": {
     "date-fns": "^3.0.6",
     "lodash": "^4.17.21",
-    "zod": "^3.25.76"
+    "zod": "^3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",
@@ -28,9 +25,14 @@
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },
+  "typesVersions": {
+    "*": {
+      "*": ["dist/*", "src/*"]
+    }
+  },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
@@ -46,6 +48,7 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -6,38 +6,11 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
-    "skipLibCheck": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-    "rootDir": "src",
-    "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": false,
     "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": false,
-    "target": "ES2022",
-    "types": [
-      "node"
-    ],
-    "baseUrl": ".",
-    "paths": {}
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,18 +1,16 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
-    'leads/index': 'src/leads/index.ts',
-    'tickets/index': 'src/tickets/index.ts',
+    "index": "src/index.ts",
+    "leads/index": "src/leads/index.ts",
+    "tickets/index": "src/tickets/index.ts"
   },
-  format: ['cjs', 'esm'],
-  target: 'es2022',
-  dts: false,
-  dts: true,
-  sourcemap: true,
   splitting: false,
+  sourcemap: true,
   clean: true,
-  external: ['zod', 'lodash', 'date-fns'],
-  tsconfig: './tsconfig.build.json',
+  dts: true,
+  format: ["cjs", "esm"],
+  target: "es2022",
+  tsconfig: "./tsconfig.build.json"
 });

--- a/packages/integrations/index.d.ts
+++ b/packages/integrations/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -4,16 +4,13 @@
   "description": "Integrações externas do sistema Ticketz-LeadEngine",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
-    "build": "tsup && pnpm run build:types",
-    "build:clean": "tsup --clean && pnpm run build:types",
-    "build:types": "tsc -p tsconfig.build.json",
     "build": "tsup",
     "build:clean": "tsup --clean",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
-    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -30,14 +27,20 @@
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },
+  "typesVersions": {
+    "*": {
+      "*": ["dist/*", "src/*"]
+    }
+  },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }

--- a/packages/integrations/tsconfig.build.json
+++ b/packages/integrations/tsconfig.build.json
@@ -6,38 +6,11 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
-    "skipLibCheck": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-    "rootDir": "src",
-    "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": false,
     "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": false,
-    "target": "ES2022",
-    "types": [
-      "node"
-    ],
-    "baseUrl": ".",
-    "paths": {}
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/integrations/tsup.config.ts
+++ b/packages/integrations/tsup.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
+    "index": "src/index.ts"
   },
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: false,
-  format: ['cjs', 'esm'],
-  target: 'es2022',
-  external: ['@ticketz/core', '@whiskeysockets/baileys', '@hapi/boom'],
-  tsconfig: './tsconfig.build.json',
+  dts: true,
+  format: ["cjs", "esm"],
+  target: "es2022",
+  external: ["@whiskeysockets/baileys", "@hapi/boom"],
+  tsconfig: "./tsconfig.build.json"
 });

--- a/packages/shared/index.d.ts
+++ b/packages/shared/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,34 +4,38 @@
   "description": "Código compartilhado do sistema Ticketz-LeadEngine",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
-    "build": "tsup && pnpm run build:types",
-    "build:clean": "tsup --clean && pnpm run build:types",
-    "build:types": "tsc -p tsconfig.build.json",
+    "build": "tsup",
+    "build:clean": "tsup --clean",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
-    "typecheck": "tsc -p tsconfig.build.json --noEmit",
-    "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
     "winston": "^3.11.0",
-    "zod": "^3.25.76"
+    "zod": "^3"
   },
   "devDependencies": {
     "tsup": "^8.5.0",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },
+  "typesVersions": {
+    "*": {
+      "*": ["dist/*", "src/*"]
+    }
+  },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -6,13 +6,11 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "skipLibCheck": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,14 +1,14 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
+    "index": "src/index.ts"
   },
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: false,
-  format: ['cjs', 'esm'],
-  target: 'es2022',
-  tsconfig: './tsconfig.build.json',
+  dts: true,
+  format: ["cjs", "esm"],
+  target: "es2022",
+  tsconfig: "./tsconfig.build.json"
 });

--- a/packages/storage/index.d.ts
+++ b/packages/storage/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -4,16 +4,13 @@
   "description": "Camada de persistência do sistema Ticketz-LeadEngine",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
-    "build": "tsup && pnpm run build:types",
-    "build:clean": "tsup --clean && pnpm run build:types",
-    "build:types": "tsc -p tsconfig.build.json",
     "build": "tsup",
     "build:clean": "tsup --clean",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "dev": "tsup --watch",
     "test": "vitest --passWithNoTests",
-    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -24,14 +21,20 @@
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"
   },
+  "typesVersions": {
+    "*": {
+      "*": ["dist/*", "src/*"]
+    }
+  },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }

--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -6,43 +6,11 @@
     "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
-    "skipLibCheck": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.d.ts"
-  ],
-  "references": [
-    {
-      "path": "../core"
-    }
-    "rootDir": "src",
-    "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": false,
     "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": false,
-    "target": "ES2022",
-    "types": [
-      "node"
-    ],
-    "baseUrl": ".",
-    "paths": {}
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/storage/tsup.config.ts
+++ b/packages/storage/tsup.config.ts
@@ -1,19 +1,15 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
-    index: 'src/index.ts',
+    "index": "src/index.ts"
   },
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
-  target: 'es2022',
-  dts: true,
   splitting: false,
   sourcemap: true,
   clean: true,
-  dts: false,
-  format: ['cjs', 'esm'],
-  target: 'es2022',
-  external: ['@ticketz/core'],
-  tsconfig: './tsconfig.build.json',
+  dts: true,
+  format: ["cjs", "esm"],
+  target: "es2022",
+  external: ["@ticketz/core"],
+  tsconfig: "./tsconfig.build.json"
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,7 +345,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       zod:
-        specifier: ^3.25.76
+        specifier: ^3
         version: 3.25.76
     devDependencies:
       '@types/lodash':
@@ -401,7 +401,7 @@ importers:
         specifier: ^3.11.0
         version: 3.17.0
       zod:
-        specifier: ^3.25.76
+        specifier: ^3
         version: 3.25.76
     devDependencies:
       tsup:


### PR DESCRIPTION
## Summary
- enforce the cross-package import guard in ESLint and collapse the CI workflow to the pinned Node 20/Corepack/pnpm toolchain
- document and standardize the library ➜ API build flow (local and Render) while reordering the API build:dependencies script to typecheck before bundling
- refresh @ticketz/{core,storage,integrations,shared} configs with NodeNext tsconfigs, clean scripts, tsup dts settings, package metadata, and handoff index.d.ts shims for type resolution

## Testing
- pnpm -w install --frozen-lockfile
- pnpm -F @ticketz/api run db:generate
- pnpm -F @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e286676c5883328ed35656ba64c52b