### PR TITLE
chore: harden render build and guardrails

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,7 @@
-node-linker=isolated
-virtual-store-dir=node_modules/.pnpm
-
-shared-workspace-lockfile=true
-link-workspace-packages=true
-prefer-workspace-packages=true
-strict-peer-dependencies=true
-engine-strict=true
+node-linker = isolated
+virtual-store-dir = node_modules/.pnpm
+shared-workspace-lockfile = true
+strict-peer-dependencies = true
+link-workspace-packages = true
+prefer-workspace-packages = true
+engine-strict = true

--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -127,7 +127,14 @@ Caso utilize o Render.com para hospedar a API como serviço web, configure os co
 
 | Etapa | Comando |
 | --- | --- |
-| Build Command | `corepack enable && corepack prepare pnpm@9.12.3 --activate && pnpm -w install --frozen-lockfile --prod=false && pnpm -w prisma generate --schema=prisma/schema.prisma && pnpm -F @ticketz/api build` |
+| Build Command | <pre><code>corepack enable \
+&& corepack prepare pnpm@9.12.3 --activate \
+&& pnpm fetch \
+&& pnpm -r install --frozen-lockfile --prod=false \
+&& pnpm run doctor \
+&& pnpm -F @ticketz/integrations exec node -e "const {createRequire}=require('node:module');const r=createRequire(require('node:path').resolve('packages/integrations/package.json'));console.log(r.resolve('@whiskeysockets/baileys/package.json'));console.log(r.resolve('@hapi/boom/package.json'))" \
+&& pnpm -w prisma generate --schema=prisma/schema.prisma \
+&& pnpm -F @ticketz/api build</code></pre> |
 | Start Command | `./node_modules/.bin/prisma migrate deploy --schema=prisma/schema.prisma && node apps/api/dist/server.js` |
 | Node version | Defina `NODE_VERSION=20` (ou use a configuração padrão do Render baseada no `package.json`) |
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "description": "API REST para o sistema Ticketz-LeadEngine",
   "main": "dist/server.js",
   "scripts": {
-    "build:dependencies": "pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck && pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean",
+    "build:dependencies": "pnpm -r install --frozen-lockfile --prod=false && pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run typecheck && pnpm --filter @ticketz/core --filter @ticketz/storage --filter @ticketz/integrations run build:clean",
     "build": "pnpm run build:dependencies && pnpm run db:generate && tsup",
     "dev": "tsx watch src/server.ts",
     "prestart": "pnpm run build:dependencies && pnpm run db:generate",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=20.19 <21"
+    "node": ">=20.19 <21",
+    "pnpm": "9.12.3"
   },
   "packageManager": "pnpm@9.12.3",
   "pnpm": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -13,7 +13,9 @@
     }
   },
   "scripts": {
+    "pretypecheck": "node -e \"require.resolve('@whiskeysockets/baileys'); require.resolve('@hapi/boom')\"",
     "typecheck": "tsc -p tsconfig.build.json --noEmit",
+    "typecheck:trace": "tsc -p tsconfig.build.json --noEmit --traceResolution",
     "build": "tsup",
     "build:clean": "tsup --clean"
   },


### PR DESCRIPTION
## Summary
- document the multi-step Render build command that verifies dependencies before building the API
- ensure integrations package resolves baileys and boom before type checking and add tracing helper
- make the API build pipeline reinstall dependencies before checking types and clean builds while enforcing pnpm engine constraints

## Testing
- node -v
- corepack enable && corepack prepare pnpm@9.12.3 --activate
- pnpm fetch
- pnpm -r install --frozen-lockfile --prod=false
- pnpm run doctor
- pnpm --filter @ticketz/integrations list --depth 0
- grep -n "@whiskeysockets/baileys\|@hapi/boom" pnpm-lock.yaml
- pnpm --filter @ticketz/integrations exec node -p "require.resolve('@whiskeysockets/baileys/package.json')"
- pnpm --filter @ticketz/integrations exec node -p "require.resolve('@hapi/boom/package.json')"
- pnpm --filter @ticketz/integrations exec sed -n '1,40p' src/whatsapp/baileys-provider.ts
- pnpm --filter @ticketz/integrations run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2c1367c9883328b1bd87d2b5f8945