### PR TITLE
Add polling fallback for inbox Socket.IO connection

### DIFF
--- a/apps/web/src/features/leads/inbox/README.md
+++ b/apps/web/src/features/leads/inbox/README.md
@@ -5,6 +5,7 @@ Fluxo consumido pelos agentes após a conexão do WhatsApp.
 1. `useLeadAllocations` -> GET `/api/lead-engine/allocations` + patch status.
 2. `NoticeBanner` indica atualização automática a cada 15s (polling + socket fallback).
 3. `useInboxLiveUpdates` (opcional) assina `leadengine:inbox:new` quando disponível via Socket.IO.
+   - Prioriza WebSockets, mas força fallback para `polling` quando o ambiente bloqueia a conexão (ex.: Render sem suporte a WS).
 
 ## Contratos
 

--- a/apps/web/src/features/whatsapp-inbound/sockets/useInboxLiveUpdates.js
+++ b/apps/web/src/features/whatsapp-inbound/sockets/useInboxLiveUpdates.js
@@ -17,6 +17,7 @@ export const useInboxLiveUpdates = ({ tenantId, enabled = true, onLead }) => {
   const socketRef = useRef(null);
   const [connected, setConnected] = useState(false);
   const [connectionError, setConnectionError] = useState(null);
+  const fallbackAttemptedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled || !tenantId) {
@@ -24,6 +25,7 @@ export const useInboxLiveUpdates = ({ tenantId, enabled = true, onLead }) => {
     }
 
     let isMounted = true;
+    fallbackAttemptedRef.current = false;
 
     const connect = async () => {
       try {
@@ -33,36 +35,60 @@ export const useInboxLiveUpdates = ({ tenantId, enabled = true, onLead }) => {
         }
 
         const token = getAuthToken();
-        const socket = io(resolveSocketUrl(), {
-          path: '/socket.io',
-          transports: ['websocket'],
-          auth: token ? { token } : undefined,
-        });
-
-        socketRef.current = socket;
-
-        socket.on('connect', () => {
-          if (!isMounted) return;
-          setConnected(true);
-          setConnectionError(null);
-          socket.emit('join-tenant', tenantId);
-        });
-
-        socket.on('disconnect', () => {
-          if (!isMounted) return;
-          setConnected(false);
-        });
-
-        socket.on('connect_error', (error) => {
-          if (!isMounted) return;
-          setConnectionError(error instanceof Error ? error.message : 'Falha ao conectar no tempo real');
-        });
-
-        socket.on('leadengine:inbox:new', (payload) => {
-          if (typeof onLead === 'function') {
-            onLead(payload);
+        const initializeSocket = (transports) => {
+          if (!isMounted) {
+            return;
           }
-        });
+
+          if (socketRef.current) {
+            socketRef.current.removeAllListeners();
+            socketRef.current.disconnect();
+          }
+
+          const socket = io(resolveSocketUrl(), {
+            path: '/socket.io',
+            transports,
+            auth: token ? { token } : undefined,
+          });
+
+          socketRef.current = socket;
+
+          socket.on('connect', () => {
+            if (!isMounted) return;
+            setConnected(true);
+            setConnectionError(null);
+            socket.emit('join-tenant', tenantId);
+          });
+
+          socket.on('disconnect', () => {
+            if (!isMounted) return;
+            setConnected(false);
+          });
+
+          socket.on('connect_error', (error) => {
+            if (!isMounted) return;
+            const message =
+              error instanceof Error
+                ? error.message
+                : 'Falha ao conectar no tempo real';
+            setConnectionError(message);
+
+            if (transports.includes('websocket') && !fallbackAttemptedRef.current) {
+              fallbackAttemptedRef.current = true;
+              setConnected(false);
+              setConnectionError('Falha ao conectar via WebSocket. Tentando reconectar via polling.');
+              initializeSocket(['polling']);
+            }
+          });
+
+          socket.on('leadengine:inbox:new', (payload) => {
+            if (typeof onLead === 'function') {
+              onLead(payload);
+            }
+          });
+        };
+
+        initializeSocket(['websocket', 'polling']);
       } catch (error) {
         if (!isMounted) {
           return;
@@ -75,7 +101,9 @@ export const useInboxLiveUpdates = ({ tenantId, enabled = true, onLead }) => {
 
     return () => {
       isMounted = false;
+      fallbackAttemptedRef.current = false;
       if (socketRef.current) {
+        socketRef.current.removeAllListeners();
         socketRef.current.disconnect();
         socketRef.current = null;
       }


### PR DESCRIPTION
## Summary
- allow the inbox live updates hook to negotiate both websocket and polling transports when starting the Socket.IO client
- automatically retry the connection using only HTTP polling when a websocket transport cannot be established
- document the fallback behaviour in the inbox README for agents using environments without websocket support

## Testing
- not run (Render environment required for verification)


------
https://chatgpt.com/codex/tasks/task_e_68e3c75b6ed48332aeb1fbbefbbaa6df