### PR TITLE
Add ticket socket room handlers and typing broadcast

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -27,6 +27,7 @@ import { queuesRouter } from './routes/queues';
 import { ticketMessagesRouter } from './routes/messages.ticket';
 import { contactMessagesRouter } from './routes/messages.contact';
 import { whatsappMessagesRouter } from './routes/integrations/whatsapp.messages';
+import { registerSocketConnectionHandlers } from './socket/connection-handlers';
 
 if (process.env.NODE_ENV !== 'production') {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -309,25 +310,7 @@ io.engine.on('connection_error', (err) => {
   });
 });
 
-io.on('connection', (socket) => {
-  logger.info(`Client connected: ${socket.id}`);
-  
-  // Juntar-se a sala do tenant
-  socket.on('join-tenant', (tenantId: string) => {
-    socket.join(`tenant:${tenantId}`);
-    logger.info(`Client ${socket.id} joined tenant ${tenantId}`);
-  });
-  
-  // Juntar-se a sala de usuário
-  socket.on('join-user', (userId: string) => {
-    socket.join(`user:${userId}`);
-    logger.info(`Client ${socket.id} joined user ${userId}`);
-  });
-  
-  socket.on('disconnect', () => {
-    logger.info(`Client disconnected: ${socket.id}`);
-  });
-});
+io.on('connection', registerSocketConnectionHandlers);
 
 // Root availability check
 const rootAvailabilityPayload = {

--- a/apps/api/src/socket/__tests__/connection-handlers.spec.ts
+++ b/apps/api/src/socket/__tests__/connection-handlers.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Socket } from 'socket.io';
+
+import { registerSocketConnectionHandlers } from '../connection-handlers';
+import { emitToTicket } from '../../lib/socket-registry';
+import { logger } from '../../config/logger';
+
+vi.mock('../../config/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/socket-registry', () => ({
+  emitToTicket: vi.fn(),
+}));
+
+type RegisteredHandlers = Record<string, (payload: any) => void>;
+
+type FakeSocket = Socket & {
+  handlers: RegisteredHandlers;
+};
+
+const createFakeSocket = (): FakeSocket => {
+  const handlers: RegisteredHandlers = {};
+  const join = vi.fn();
+  const leave = vi.fn().mockResolvedValue(undefined);
+
+  const socket = {
+    id: 'socket-123',
+    handshake: { address: '::1', auth: {} },
+    handlers,
+    on: vi.fn((event: string, handler: (payload: any) => void) => {
+      handlers[event] = handler;
+      return socket;
+    }),
+    join,
+    leave,
+  } as unknown as FakeSocket;
+
+  return socket;
+};
+
+describe('registerSocketConnectionHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('joins the provided ticket room when receiving join-ticket', () => {
+    const socket = createFakeSocket();
+
+    registerSocketConnectionHandlers(socket);
+
+    socket.handlers['join-ticket']?.('ticket-1');
+
+    expect(socket.join).toHaveBeenCalledWith('ticket:ticket-1');
+    expect(logger.info).toHaveBeenCalledWith('Client socket-123 joined ticket ticket-1');
+  });
+
+  it('leaves the ticket room when receiving leave-ticket', () => {
+    const socket = createFakeSocket();
+
+    registerSocketConnectionHandlers(socket);
+
+    socket.handlers['leave-ticket']?.('ticket-2');
+
+    expect(socket.leave).toHaveBeenCalledWith('ticket:ticket-2');
+    expect(logger.info).toHaveBeenCalledWith('Client socket-123 left ticket ticket-2');
+  });
+
+  it('broadcasts typing payloads to the ticket room', () => {
+    const socket = createFakeSocket();
+    const payload = { ticketId: 'ticket-3', timestamp: 123456 };
+
+    registerSocketConnectionHandlers(socket);
+
+    socket.handlers['ticket:typing']?.(payload);
+
+    expect(emitToTicket).toHaveBeenCalledWith('ticket-3', 'ticket:typing', payload);
+    expect(logger.info).toHaveBeenCalledWith('Client socket-123 typing on ticket ticket-3');
+  });
+
+  it('logs a warning when typing payload lacks ticketId', () => {
+    const socket = createFakeSocket();
+
+    registerSocketConnectionHandlers(socket);
+
+    socket.handlers['ticket:typing']?.({ timestamp: 987 });
+
+    expect(emitToTicket).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith('Client socket-123 sent ticket:typing without ticketId', {
+      payload: { timestamp: 987 },
+    });
+  });
+});

--- a/apps/api/src/socket/connection-handlers.ts
+++ b/apps/api/src/socket/connection-handlers.ts
@@ -1,0 +1,49 @@
+import type { Socket } from 'socket.io';
+
+import { logger } from '../config/logger';
+import { emitToTicket } from '../lib/socket-registry';
+
+type TicketTypingPayload = {
+  ticketId?: string;
+  [key: string]: unknown;
+};
+
+export const registerSocketConnectionHandlers = (socket: Socket): void => {
+  logger.info(`Client connected: ${socket.id}`);
+
+  socket.on('join-tenant', (tenantId: string) => {
+    socket.join(`tenant:${tenantId}`);
+    logger.info(`Client ${socket.id} joined tenant ${tenantId}`);
+  });
+
+  socket.on('join-user', (userId: string) => {
+    socket.join(`user:${userId}`);
+    logger.info(`Client ${socket.id} joined user ${userId}`);
+  });
+
+  socket.on('join-ticket', (ticketId: string) => {
+    socket.join(`ticket:${ticketId}`);
+    logger.info(`Client ${socket.id} joined ticket ${ticketId}`);
+  });
+
+  socket.on('leave-ticket', (ticketId: string) => {
+    void socket.leave(`ticket:${ticketId}`);
+    logger.info(`Client ${socket.id} left ticket ${ticketId}`);
+  });
+
+  socket.on('ticket:typing', (payload: TicketTypingPayload) => {
+    const ticketId = payload?.ticketId;
+
+    if (!ticketId) {
+      logger.warn(`Client ${socket.id} sent ticket:typing without ticketId`, { payload });
+      return;
+    }
+
+    emitToTicket(ticketId, 'ticket:typing', payload);
+    logger.info(`Client ${socket.id} typing on ticket ${ticketId}`);
+  });
+
+  socket.on('disconnect', () => {
+    logger.info(`Client disconnected: ${socket.id}`);
+  });
+};


### PR DESCRIPTION
## Summary
- add a dedicated socket connection handler module that manages tenant, user, and ticket rooms with logging
- broadcast `ticket:typing` events to the ticket room via `emitToTicket` and handle missing ticket ids
- cover the new handlers with unit tests validating join/leave flows and typing broadcasts

## Testing
- pnpm --filter @ticketz/api exec vitest run src/socket/__tests__/connection-handlers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3c7525f00833289daa39687cefa73