### PR TITLE
Adjust WhatsApp instance loading fallback handling

### DIFF
--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -1365,7 +1365,15 @@ const WhatsAppConnect = ({
 
       if (!Array.isArray(list) || list.length === 0) {
         const fallbackInstanceId = preferredInstanceId || campaign?.instanceId || null;
-        connectResult = connectResult || (await connectInstance(fallbackInstanceId));
+        if (fallbackInstanceId) {
+          connectResult = connectResult || (await connectInstance(fallbackInstanceId));
+        } else {
+          warn('Nenhuma instância padrão disponível para conexão automática', {
+            agreementId,
+            preferredInstanceId: preferredInstanceId ?? null,
+            campaignInstanceId: campaign?.instanceId ?? null,
+          });
+        }
 
         if (connectResult?.instances?.length) {
           list = connectResult.instances;
@@ -1467,12 +1475,18 @@ const WhatsAppConnect = ({
       });
       return { success: true, status: statusFromInstance };
     } catch (err) {
+      const status = err?.response?.status;
+      const errorCode = err?.response?.data?.code ?? err?.code;
+      const isMissingInstanceError = status === 404 || errorCode === 'INSTANCE_NOT_FOUND';
+
       if (isAuthError(err)) {
         handleAuthFallback();
-      } else {
+      } else if (!isMissingInstanceError) {
         setErrorMessage(
           err instanceof Error ? err.message : 'Não foi possível carregar status do WhatsApp'
         );
+      } else {
+        setErrorMessage(null);
       }
       warn('Instâncias não puderam ser carregadas', err);
       return { success: false, error: err, skipped: isAuthError(err) };


### PR DESCRIPTION
## Summary
- avoid attempting to connect without a fallback instance id and log when none is present
- ignore 404 and INSTANCE_NOT_FOUND errors while loading instances so the creation CTA remains available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d2200df08332a0bca298673d539c