### PR TITLE
Fix WhatsApp status error handling syntax

### DIFF
--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -1617,13 +1617,10 @@ const WhatsAppConnect = ({
 
       if (isAuthError(err)) {
         handleAuthFallback();
-      } else {
+      } else if (!isMissingInstanceError) {
         applyErrorMessageFromError(
           err,
           'Não foi possível carregar status do WhatsApp'
-      } else if (!isMissingInstanceError) {
-        setErrorMessage(
-          err instanceof Error ? err.message : 'Não foi possível carregar status do WhatsApp'
         );
       } else {
         setErrorMessage(null);


### PR DESCRIPTION
## Summary
- fix the misplaced braces in the WhatsApp connection error handler that broke the build
- ensure non-auth errors continue to display a friendly message while missing-instance errors clear the banner

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e4024a64088332a5ecb28ef7fdb6fc