### PR TITLE
Fix WhatsApp error message handling

### DIFF
--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -1621,12 +1621,14 @@ const WhatsAppConnect = ({
         applyErrorMessageFromError(
           err,
           'Não foi possível carregar status do WhatsApp'
-      } else if (!isMissingInstanceError) {
-        setErrorMessage(
-          err instanceof Error ? err.message : 'Não foi possível carregar status do WhatsApp'
         );
-      } else {
-        setErrorMessage(null);
+        if (!isMissingInstanceError) {
+          setErrorMessage(
+            err instanceof Error ? err.message : 'Não foi possível carregar status do WhatsApp'
+          );
+        } else {
+          setErrorMessage(null);
+        }
       }
       warn('Instâncias não puderam ser carregadas', err);
       return { success: false, error: err, skipped: isAuthError(err) };


### PR DESCRIPTION
## Summary
- ensure WhatsApp connect error handling closes the applyErrorMessageFromError invocation
- scope non-auth error message updates so missing-instance errors clear the UI state instead of showing stale text

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e407ff1ca883329722c5f704c914ef