### PR TITLE
Align API build with Node 20 and fix dotenv import

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,7 @@ import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 import { createServer, type IncomingMessage, type ServerResponse } from 'http';
 import { Server as SocketIOServer } from 'socket.io';
+import dotenv from 'dotenv';
 
 import { errorHandler } from './middleware/error-handler';
 import { requestLogger } from './middleware/request-logger';
@@ -30,8 +31,7 @@ import { whatsappMessagesRouter } from './routes/integrations/whatsapp.messages'
 import { registerSocketConnectionHandlers } from './socket/connection-handlers';
 
 if (process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  require('dotenv').config();
+  dotenv.config();
 }
 
 const app: Application = express();

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -3,12 +3,13 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/server.ts'],
   format: ['cjs'],
+  bundle: false,
   dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,
   minify: false,
-  target: 'node18',
+  target: 'node20',
   external: [
     '@ticketz/core',
     '@ticketz/shared',

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
-const resolvePackageRoot = (pkg: string) => path.resolve(__dirname, `../../packages/${pkg}/src`);
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const resolvePackageRoot = (pkg: string) => path.resolve(currentDir, `../../packages/${pkg}/src`);
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- align the API tsup configuration with the Node 20 runtime and disable bundling to avoid CommonJS export parsing errors
- load dotenv through an explicit import so development mode works without require
- update the Vitest config to resolve package aliases without relying on __dirname

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e40b726aec8332b3caecad3b93f973