### PR TITLE
Fix API build bundling error by enabling tsup bundling

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -1182,9 +1182,6 @@ const syncInstancesFromBroker = async (
   prefetchedSnapshots?: WhatsAppBrokerInstanceSnapshot[]
 ): Promise<SyncInstancesResult> => {
   const brokerSnapshots = prefetchedSnapshots ?? (await whatsappBrokerClient.listInstances(tenantId));
-const syncInstancesFromBroker = async (tenantId: string, existing: StoredInstance[]): Promise<StoredInstance[]> => {
-  const brokerSnapshots = await whatsappBrokerClient.listInstances(tenantId);
-
   if (!brokerSnapshots.length) {
     logger.info('🛰️ [WhatsApp] Broker returned zero instances', { tenantId });
     return { instances: existing, snapshots: brokerSnapshots };

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -3,13 +3,14 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/server.ts'],
   format: ['cjs'],
-  bundle: false,
+  bundle: true,
   dts: false,
   splitting: false,
   sourcemap: true,
   clean: true,
   minify: false,
   target: 'node20',
+  outDir: 'dist',
   external: [
     '@ticketz/core',
     '@ticketz/shared',


### PR DESCRIPTION
## Summary
- enable bundling for the API tsup build so local modules are emitted into dist
- clean up a duplicate syncInstancesFromBroker declaration that was preventing the bundler from walking the module graph

## Testing
- pnpm tsup

------
https://chatgpt.com/codex/tasks/task_e_68e418da92808332a239191ac00a5750