### PR TITLE
feat: harden WhatsApp instance lifecycle

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -151,7 +151,7 @@ export interface WhatsAppQrCode {
 }
 
 export interface WhatsAppStatus extends WhatsAppQrCode {
-  status: 'connected' | 'connecting' | 'disconnected' | 'qr_required';
+  status: 'connected' | 'connecting' | 'disconnected' | 'qr_required' | 'pending' | 'failed';
   connected: boolean;
   stats?: Record<string, unknown> | null;
   metrics?: Record<string, unknown> | null;
@@ -231,11 +231,13 @@ class WhatsAppBrokerClient {
   }
 
   private get baseUrl(): string {
-    return process.env.WHATSAPP_BROKER_URL?.replace(/\/$/, '') || '';
+    const configured = (process.env.BROKER_BASE_URL || process.env.WHATSAPP_BROKER_URL || '').trim();
+    return configured ? configured.replace(/\/$/, '') : '';
   }
 
   private get brokerApiKey(): string {
-    return process.env.WHATSAPP_BROKER_API_KEY || '';
+    const configured = (process.env.BROKER_API_KEY || process.env.WHATSAPP_BROKER_API_KEY || '').trim();
+    return configured;
   }
 
   private get shouldStripLegacyPlus(): boolean {
@@ -265,8 +267,16 @@ class WhatsAppBrokerClient {
       throw new WhatsAppBrokerNotConfiguredError(message);
     }
 
-    if (!this.baseUrl || !this.brokerApiKey) {
-      throw new WhatsAppBrokerNotConfiguredError();
+    if (!this.baseUrl) {
+      throw new WhatsAppBrokerNotConfiguredError(
+        'WhatsApp broker base URL is not configured. Set BROKER_BASE_URL or WHATSAPP_BROKER_URL.'
+      );
+    }
+
+    if (!this.brokerApiKey) {
+      throw new WhatsAppBrokerNotConfiguredError(
+        'WhatsApp broker API key is not configured. Set BROKER_API_KEY or WHATSAPP_BROKER_API_KEY.'
+      );
     }
   }
 

--- a/prisma/migrations/20250206000100_add_pending_failed_whatsapp_status/migration.sql
+++ b/prisma/migrations/20250206000100_add_pending_failed_whatsapp_status/migration.sql
@@ -1,0 +1,5 @@
+ALTER TYPE "WhatsAppInstanceStatus" ADD VALUE IF NOT EXISTS 'pending';
+ALTER TYPE "WhatsAppInstanceStatus" ADD VALUE IF NOT EXISTS 'failed';
+
+ALTER TABLE "whatsapp_instances"
+  ALTER COLUMN "status" SET DEFAULT 'pending';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -289,6 +289,8 @@ enum WhatsAppInstanceStatus {
   connecting
   connected
   error
+  pending
+  failed
 }
 
 model WhatsAppInstance {
@@ -297,7 +299,7 @@ model WhatsAppInstance {
   name        String
   brokerId    String
   phoneNumber String?
-  status      WhatsAppInstanceStatus   @default(disconnected)
+  status      WhatsAppInstanceStatus   @default(pending)
   connected   Boolean                  @default(false)
   lastSeenAt  DateTime?
   createdAt   DateTime                 @default(now())


### PR DESCRIPTION
## Summary
- extend WhatsApp instance lifecycle with pending/failed states, agreement tracking, and last-error metadata persisted in storage
- add broker connection safeguards, new /connect alias, and descriptive error mapping when the broker rejects a connect request
- expose agreementId filtering metadata in listings and warn when no instances match the selected agreement

## Testing
- pnpm --filter @ticketz/api run db:generate
- pnpm --filter @ticketz/api run typecheck *(fails: repository lacks generated @ticketz/core/@ticketz/storage type declarations and existing schemas need fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68e444c670108332a326b229dbb44fe5