### PR TITLE
Handle Prisma validation errors when creating WhatsApp instances

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -2081,6 +2081,41 @@ router.post(
         return;
       }
 
+      if (error instanceof Prisma.PrismaClientValidationError) {
+        logger.error('WhatsApp instance creation rejected: invalid payload', {
+          tenantId,
+          error,
+        });
+
+        res.status(400).json({
+          success: false,
+          error: {
+            code: 'INVALID_INSTANCE_PAYLOAD',
+            message:
+              'Não foi possível criar a instância WhatsApp. Verifique os dados enviados e tente novamente.',
+          },
+        });
+        return;
+      }
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        logger.error('WhatsApp instance creation failed due to storage error', {
+          tenantId,
+          code: error.code,
+          meta: error.meta,
+        });
+
+        res.status(503).json({
+          success: false,
+          error: {
+            code: 'WHATSAPP_STORAGE_UNAVAILABLE',
+            message:
+              'Serviço de armazenamento das instâncias WhatsApp indisponível. Verifique a conexão com o banco ou execute as migrações pendentes.',
+          },
+        });
+        return;
+      }
+
       throw error;
     }
   })


### PR DESCRIPTION
## Summary
- add explicit Prisma validation and storage error handling when creating WhatsApp instances so clients receive friendly messages
- mock the socket registry and extend integration tests to cover Prisma validation failures during instance creation

## Testing
- pnpm --filter @ticketz/api exec vitest run src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4532b54288332a8000d70e5763178