### PR TITLE
Add agreement metadata to WhatsApp instance creation request

### DIFF
--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -2059,6 +2059,9 @@ const WhatsAppConnect = ({
     }
 
     const payloadBody = {
+      agreementId: selectedAgreement.id,
+      agreementName: selectedAgreement.name ?? undefined,
+      tenantId: selectedAgreement.tenantId ?? undefined,
       name: normalizedName,
       ...(id ? { id: `${id}`.trim() } : {}),
     };


### PR DESCRIPTION
## Summary
- include agreement metadata when creating a WhatsApp instance so the API receives the agreement context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4533bb1848332a0b248b3c8706283