### PR TITLE
Allow WhatsApp instances to display across agreements

### DIFF
--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -940,6 +940,9 @@ const normalizeInstancesCollection = (rawList, options = {}) => {
         .map((value) => value.trim())
         .filter((value) => value.length > 0)
     : [];
+  const shouldFilterByTenant =
+    (options.filterByTenant === true || options.enforceTenantScope === true) &&
+    allowedTenants.length > 0;
 
   const order = [];
   const map = new Map();
@@ -955,7 +958,7 @@ const normalizeInstancesCollection = (rawList, options = {}) => {
     }
 
     if (
-      allowedTenants.length > 0 &&
+      shouldFilterByTenant &&
       normalized.tenantId &&
       !allowedTenants.includes(normalized.tenantId)
     ) {
@@ -1761,12 +1764,7 @@ const WhatsAppConnect = ({
         list = list.map((item) => (item.id === candidate.id ? { ...item, ...candidate } : item));
       }
 
-      const allowedTenants = [selectedAgreement?.tenantId, selectedAgreement?.id]
-        .filter((value) => typeof value === 'string')
-        .map((value) => value.trim())
-        .filter((value) => value.length > 0);
-
-      const normalizedList = normalizeInstancesCollection(list, { allowedTenants });
+      const normalizedList = normalizeInstancesCollection(list);
       list = normalizedList;
 
       if (current) {


### PR DESCRIPTION
## Summary
- stop automatically filtering WhatsApp instances by the selected convênio when loading data
- make tenant scoping in normalizeInstancesCollection optional so non-scoped requests keep all instances

## Testing
- pnpm --filter web lint *(fails: existing lint warnings and unused variable error in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e45cedf0ec833296376334f164059a