### PR TITLE
Adjust dialog overlays to darker backdrop

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.jsx
+++ b/apps/web/src/components/ui/alert-dialog.jsx
@@ -32,7 +32,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 backdrop-blur-sm",
         className
       )}
       {...props} />

--- a/apps/web/src/components/ui/dialog.jsx
+++ b/apps/web/src/components/ui/dialog.jsx
@@ -36,7 +36,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 backdrop-blur-sm",
         className
       )}
       {...props} />


### PR DESCRIPTION
## Summary
- darken the standard dialog overlay to use an 80% black backdrop with a subtle blur
- apply the same darker overlay treatment to alert dialogs for consistent styling

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e46139c1648332935b86b74148dbb3