### PR TITLE
Fix WhatsApp broker misconfiguration handling

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -1478,6 +1478,7 @@ class WhatsAppBrokerClient {
     brokerId: string,
     options: { instanceId?: string; webhookUrl?: string; forceReopen?: boolean } = {}
   ): Promise<void> {
+    this.ensureConfigured();
     await this.connectSession(brokerId, { ...options, instanceId: options.instanceId ?? brokerId });
   }
 
@@ -1485,6 +1486,7 @@ class WhatsAppBrokerClient {
     brokerId: string,
     options: { instanceId?: string; wipe?: boolean } = {}
   ): Promise<void> {
+    this.ensureConfigured();
     await this.logoutSession(brokerId, { ...options, instanceId: options.instanceId ?? brokerId });
   }
 
@@ -1492,6 +1494,7 @@ class WhatsAppBrokerClient {
     brokerId: string,
     options: { instanceId?: string; wipe?: boolean } = {}
   ): Promise<void> {
+    this.ensureConfigured();
     await this.logoutSession(brokerId, { ...options, instanceId: options.instanceId ?? brokerId });
   }
 


### PR DESCRIPTION
## Summary
- ensure the WhatsApp broker client checks configuration before connecting, disconnecting, or deleting an instance
- add regression tests covering the default connect/disconnect routes when the broker is missing

## Testing
- pnpm --filter @ticketz/api exec vitest run src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e46660243c83328016f1aef82fab6c