### PR TITLE
Normalize WhatsApp instance route parameters

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -122,6 +122,29 @@ const resolveDefaultInstanceId = (): string =>
 const looksLikeWhatsAppJid = (value: string): boolean =>
   typeof value === 'string' && value.toLowerCase().endsWith('@s.whatsapp.net');
 
+const INVALID_INSTANCE_ID_MESSAGE = 'Identificador de instância inválido.';
+
+const instanceIdParamValidator = () =>
+  param('id')
+    .custom((value, { req }) => {
+      if (typeof value !== 'string') {
+        throw new Error(INVALID_INSTANCE_ID_MESSAGE);
+      }
+
+      try {
+        const decoded = decodeURIComponent(value);
+        req.params.id = decoded;
+        return true;
+      } catch {
+        throw new Error(INVALID_INSTANCE_ID_MESSAGE);
+      }
+    })
+    .withMessage(INVALID_INSTANCE_ID_MESSAGE)
+    .bail()
+    .trim()
+    .isLength({ min: 1 })
+    .withMessage(INVALID_INSTANCE_ID_MESSAGE);
+
 const BROKER_NOT_FOUND_CODES = new Set([
   'SESSION_NOT_FOUND',
   'BROKER_SESSION_NOT_FOUND',
@@ -2327,7 +2350,7 @@ const connectInstanceHandler = async (req: Request, res: Response) => {
 };
 
 const connectInstanceMiddleware = [
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   validateRequest,
   requireTenant,
   asyncHandler(connectInstanceHandler),
@@ -2490,7 +2513,7 @@ router.post(
 // POST /api/integrations/whatsapp/instances/:id/stop - Disconnect a WhatsApp instance
 router.post(
   '/whatsapp/instances/:id/stop',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   body('wipe').optional().isBoolean(),
   validateRequest,
   requireTenant,
@@ -2580,7 +2603,7 @@ router.post(
 
 router.delete(
   '/whatsapp/instances/:id',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   query('wipe').optional().isBoolean().toBoolean(),
   validateRequest,
   requireTenant,
@@ -2717,7 +2740,7 @@ router.post(
 
 router.post(
   '/whatsapp/instances/:id/disconnect',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   body('wipe').optional().isBoolean(),
   validateRequest,
   requireTenant,
@@ -2822,7 +2845,7 @@ router.post(
 // GET /api/integrations/whatsapp/instances/:id/qr - Fetch QR code for a WhatsApp instance
 router.get(
   '/whatsapp/instances/:id/qr',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {
@@ -2871,7 +2894,7 @@ router.get(
 // GET /api/integrations/whatsapp/instances/:id/qr.png - Fetch QR code image for a WhatsApp instance
 router.get(
   '/whatsapp/instances/:id/qr.png',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {
@@ -3004,7 +3027,7 @@ router.get(
 // GET /api/integrations/whatsapp/instances/:id/status - Retrieve instance status
 router.get(
   '/whatsapp/instances/:id/status',
-  param('id').isString().isLength({ min: 1 }),
+  instanceIdParamValidator(),
   validateRequest,
   requireTenant,
   asyncHandler(async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- decode WhatsApp instance route parameters before validation to ensure handlers operate on normalized identifiers
- reuse the sanitizer across connect, disconnect, delete, QR, and status routes while leaving outbound broker requests encoded
- add a regression test that connects an instance using a URL-encoded WhatsApp JID

## Testing
- pnpm --filter @ticketz/api exec vitest run src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4734dba6c83328f14ff70b9fd3106