### PR TITLE
Fix legacy broker payload contract for Baileys

### DIFF
--- a/apps/api/src/services/__tests__/whatsapp-broker-client.spec.ts
+++ b/apps/api/src/services/__tests__/whatsapp-broker-client.spec.ts
@@ -75,6 +75,7 @@ describe('WhatsAppBrokerClient', () => {
     const parsedBody = JSON.parse(init?.body as string);
     expect(parsedBody).toEqual({
       to: '554499999999',
+      message: 'Teste via legacy',
       text: 'Teste via legacy',
       previewUrl: true,
       externalId: 'custom-id',
@@ -123,6 +124,7 @@ describe('WhatsAppBrokerClient', () => {
       text: 'Olá via broker',
       metadata: { idempotencyKey: 'idem-900', custom: true },
     });
+    expect(parsed).not.toHaveProperty('message');
     expect(parsed).not.toHaveProperty('mediaUrl');
 
     expect(result.externalId).toBe('wamid-999');
@@ -201,6 +203,13 @@ describe('WhatsAppBrokerClient', () => {
     expect(secondUrl).toBe('https://broker.test/instances/instance-fallback/send-text');
     const headers = secondInit?.headers as Headers;
     expect(headers.get('Idempotency-Key')).toBe('fallback-001');
+
+    const fallbackBody = JSON.parse(secondInit?.body as string);
+    expect(fallbackBody).toMatchObject({
+      to: '+5511888888888',
+      message: 'Mensagem com fallback',
+      text: 'Mensagem com fallback',
+    });
 
     expect(result.externalId).toBe('wamid-654');
     expect(result.status).toBe('QUEUED');

--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -642,6 +642,7 @@ class WhatsAppBrokerClient {
         body: JSON.stringify(
           compactObject({
             to: this.formatLegacyRecipient(normalizedPayload.to),
+            message: normalizedPayload.content,
             text: normalizedPayload.content,
             previewUrl: normalizedPayload.previewUrl,
             externalId: normalizedPayload.externalId,


### PR DESCRIPTION
## Summary
- add the `message` field (alongside `text`) when using legacy instance routes to satisfy Baileys
- extend whatsapp broker client tests to assert the new payload shape while keeping existing expectations

## Testing
- pnpm --filter @ticketz/api exec vitest run src/services/__tests__/whatsapp-broker-client.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e47c57d7348332903b03b439d95bd3