### PR TITLE
Update WhatsApp send routes to new broker endpoints

### DIFF
--- a/apps/api/src/routes/integrations.test.ts
+++ b/apps/api/src/routes/integrations.test.ts
@@ -1884,6 +1884,184 @@ describe('WhatsApp integration routes with configured broker', () => {
     }
   });
 
+  it('returns ack metadata when WhatsApp message is dispatched', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const brokerModule = await import('../services/whatsapp-broker-client');
+    const { whatsappBrokerClient } = brokerModule;
+
+    const sendSpy = vi.spyOn(whatsappBrokerClient, 'sendText').mockResolvedValue({
+      id: 'wamid-ack-1',
+      status: 'SERVER_ACK',
+      ack: 1,
+      rate: { limit: 10, remaining: 9, resetAt: '2024-05-05T10:00:00.000Z' },
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({ to: '5511988888888', message: 'Ack test' }),
+      });
+
+      const body = await response.json();
+
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'tenant-123', to: '5511988888888' })
+      );
+      expect(response.status).toBe(202);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          id: 'wamid-ack-1',
+          status: 'SERVER_ACK',
+          ack: 1,
+          rate: {
+            limit: 10,
+            remaining: 9,
+            resetAt: '2024-05-05T10:00:00.000Z',
+          },
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('maps ack failures from Baileys as message errors', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const brokerModule = await import('../services/whatsapp-broker-client');
+    const { whatsappBrokerClient } = brokerModule;
+
+    const sendSpy = vi.spyOn(whatsappBrokerClient, 'sendText').mockResolvedValue({
+      id: 'wamid-fail-1',
+      status: 'FAILED',
+      ack: -1,
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({ to: '5511977777777', message: 'Should fail' }),
+      });
+
+      const body = await response.json();
+
+      expect(sendSpy).toHaveBeenCalledOnce();
+      expect(response.status).toBe(502);
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: 'WHATSAPP_MESSAGE_FAILED',
+          details: { ack: -1, status: 'FAILED', id: 'wamid-fail-1' },
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('returns ack payload when creating WhatsApp polls', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const brokerModule = await import('../services/whatsapp-broker-client');
+    const { whatsappBrokerClient } = brokerModule;
+
+    const pollSpy = vi.spyOn(whatsappBrokerClient, 'createPoll').mockResolvedValue({
+      id: 'poll-123',
+      status: 'PENDING',
+      ack: 0,
+      rate: { limit: 5, remaining: 4, resetAt: '2024-05-06T12:00:00.000Z' },
+      raw: { selectableCount: 1 },
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/polls`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          to: '5511999999999',
+          question: 'Qual opção?',
+          options: ['A', 'B'],
+        }),
+      });
+
+      const body = await response.json();
+
+      expect(pollSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'tenant-123', to: '5511999999999' })
+      );
+      expect(response.status).toBe(201);
+      expect(body).toMatchObject({
+        success: true,
+        data: {
+          poll: {
+            id: 'poll-123',
+            status: 'PENDING',
+            ack: 0,
+            raw: { selectableCount: 1 },
+          },
+          rate: {
+            limit: 5,
+            remaining: 4,
+            resetAt: '2024-05-06T12:00:00.000Z',
+          },
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
+  it('propagates Baileys poll failures via error payload', async () => {
+    const { server, url } = await startTestServer({ configureWhatsApp: true });
+    const brokerModule = await import('../services/whatsapp-broker-client');
+    const { whatsappBrokerClient } = brokerModule;
+
+    const pollSpy = vi.spyOn(whatsappBrokerClient, 'createPoll').mockResolvedValue({
+      id: 'poll-failed-1',
+      status: 'FAILED',
+      ack: 'failed',
+    });
+
+    try {
+      const response = await fetch(`${url}/api/integrations/whatsapp/polls`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-tenant-id': 'tenant-123',
+        },
+        body: JSON.stringify({
+          to: '5511999999999',
+          question: 'Erro?',
+          options: ['Sim', 'Não'],
+        }),
+      });
+
+      const body = await response.json();
+
+      expect(pollSpy).toHaveBeenCalledOnce();
+      expect(response.status).toBe(502);
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: 'WHATSAPP_POLL_FAILED',
+          details: { ack: 'failed', status: 'FAILED', id: 'poll-failed-1' },
+        },
+      });
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
   it('returns broker 4xx errors with sanitized message and code', async () => {
     const { server, url } = await startTestServer({ configureWhatsApp: true });
     const brokerModule = await import('../services/whatsapp-broker-client');

--- a/apps/api/src/services/__tests__/whatsapp-broker-client.spec.ts
+++ b/apps/api/src/services/__tests__/whatsapp-broker-client.spec.ts
@@ -112,7 +112,7 @@ describe('WhatsAppBrokerClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://broker.test/instances/instance-900/messages');
+    expect(url).toBe('https://broker.test/instances/instance-900/send-text');
     expect(init?.method).toBe('POST');
 
     const headers = init?.headers as Headers;
@@ -125,10 +125,10 @@ describe('WhatsAppBrokerClient', () => {
       instanceId: 'instance-900',
       to: '+5511999999999',
       type: 'text',
+      message: 'Olá via broker',
       text: 'Olá via broker',
       metadata: { idempotencyKey: 'idem-900', custom: true },
     });
-    expect(parsed).not.toHaveProperty('message');
     expect(parsed).not.toHaveProperty('mediaUrl');
 
     expect(result.externalId).toBe('wamid-999');
@@ -159,7 +159,7 @@ describe('WhatsAppBrokerClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://broker.test/instances/instance-media/messages');
+    expect(url).toBe('https://broker.test/instances/instance-media/send-text');
     const headers = init?.headers as Headers;
     expect(headers.get('Idempotency-Key')).toBe('media-123');
 
@@ -169,6 +169,7 @@ describe('WhatsAppBrokerClient', () => {
       instanceId: 'instance-media',
       to: '+5511977777777',
       type: 'document',
+      message: 'Confira o documento',
       mediaUrl: 'https://cdn.test/doc.pdf',
       mimeType: 'application/pdf',
       fileName: 'doc.pdf',
@@ -204,22 +205,29 @@ describe('WhatsAppBrokerClient', () => {
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const [firstUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(firstUrl).toBe('https://broker.test/instances/instance-fallback/messages');
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(firstUrl).toBe('https://broker.test/instances/instance-fallback/send-text');
+    const firstBody = JSON.parse(firstInit?.body as string);
+    expect(firstBody).toMatchObject({
+      sessionId: 'instance-fallback',
+      instanceId: 'instance-fallback',
+      to: '+5511888888888',
+      type: 'text',
+      message: 'Mensagem com fallback',
+      text: 'Mensagem com fallback',
+    });
+
     const [secondUrl, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit];
     expect(secondUrl).toBe('https://broker.test/broker/messages');
     const headers = secondInit?.headers as Headers;
     expect(headers.get('Idempotency-Key')).toBe('fallback-001');
 
-    const parsedBody = JSON.parse(secondInit?.body as string);
-    expect(parsedBody).toEqual({
+    const secondBody = JSON.parse(secondInit?.body as string);
+    expect(secondBody).toMatchObject({
       sessionId: 'instance-fallback',
       instanceId: 'instance-fallback',
       to: '+5511888888888',
       type: 'text',
-    const fallbackBody = JSON.parse(secondInit?.body as string);
-    expect(fallbackBody).toMatchObject({
-      to: '+5511888888888',
       message: 'Mensagem com fallback',
       text: 'Mensagem com fallback',
     });
@@ -247,7 +255,7 @@ describe('WhatsAppBrokerClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://broker.test/instances/instance-template/messages');
+    expect(url).toBe('https://broker.test/instances/instance-template/send-text');
 
     const parsed = JSON.parse(init?.body as string);
     expect(parsed).toEqual({
@@ -255,6 +263,7 @@ describe('WhatsAppBrokerClient', () => {
       instanceId: 'instance-template',
       to: '+5511999988888',
       type: 'template',
+      message: '',
       template: { name: 'greeting_template', language: 'pt_BR' },
     });
 


### PR DESCRIPTION
## Summary
- update the WhatsApp broker client to post to `/instances/:id/send-text` or broker fallback while preserving message metadata and convert poll creation to `/send-poll`
- add ack normalization helpers so WhatsApp integrations return the new `{ id, status, ack }` response shape and surface Baileys failure codes
- refresh broker client and integrations tests to assert the new payloads, fallback behaviour, and ack-driven error handling

## Testing
- pnpm --filter @ticketz/api exec vitest run src/services/__tests__/whatsapp-broker-client.spec.ts src/routes/integrations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e47f35d2408332b14fd43772a29656