### PR TITLE
Fix WhatsApp broker session logout and status routes

### DIFF
--- a/apps/api/src/services/whatsapp-broker-client.ts
+++ b/apps/api/src/services/whatsapp-broker-client.ts
@@ -906,19 +906,9 @@ class WhatsAppBrokerClient {
     const encodedSessionId = encodeURIComponent(sessionId);
     const preferBroker = this.shouldAttemptBrokerSessionRoutes();
 
-    await this.request<void>(
-      `/instances/${encodedSessionId}/logout`,
-      {
-        method: 'POST',
-        body: JSON.stringify(
-          compactObject({
-            instanceId: options.instanceId ?? sessionId,
-            wipe: options.wipe,
-          })
-        ),
     const logoutViaLegacyRoute = async (): Promise<void> => {
       await this.request<void>(
-        `/instances/${encodedSessionId}/disconnect`,
+        `/instances/${encodedSessionId}/logout`,
         {
           method: 'POST',
           body: JSON.stringify(
@@ -1007,20 +997,6 @@ class WhatsAppBrokerClient {
       );
     }
 
-    const encodedSessionId = encodeURIComponent(sessionId);
-
-    const requestOptions: BrokerRequestOptions =
-      normalizedInstanceId && normalizedInstanceId !== sessionId
-        ? { searchParams: { instanceId: normalizedInstanceId } }
-        : {};
-
-    return this.request<T>(
-      `/instances/${encodedSessionId}`,
-      {
-        method: 'GET',
-      },
-      requestOptions
-    );
     const encodedSessionId = encodeURIComponent(sessionId);
     const preferBroker = this.shouldAttemptBrokerSessionRoutes();
 


### PR DESCRIPTION
## Summary
- define legacy and broker logout helpers before using them so tsup can parse the method
- update the session status helper to use the broker/legacy fallback logic without duplicate declarations

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e4873129dc83329d7ce7582c48585f