### PR TITLE
feat: prune inbound whatsapp dedupe cache

### DIFF
--- a/apps/api/src/features/whatsapp-inbound/services/__tests__/inbound-lead-service.dedupe.spec.ts
+++ b/apps/api/src/features/whatsapp-inbound/services/__tests__/inbound-lead-service.dedupe.spec.ts
@@ -1,0 +1,69 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../lib/prisma', () => ({
+  prisma: {},
+}));
+
+vi.mock('../../../../config/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock('../../../data/lead-allocation-store', () => ({
+  addAllocations: vi.fn(),
+}));
+
+vi.mock('../../../services/ticket-service', () => ({
+  createTicket: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock('../../../lib/socket-registry', () => ({
+  emitToTenant: vi.fn(),
+}));
+
+vi.mock('../utils/normalize', () => ({
+  normalizeInboundMessage: vi.fn(),
+}));
+
+let shouldSkipByDedupe: (key: string, now: number) => boolean;
+let testing: typeof import('../inbound-lead-service')['__testing'];
+
+beforeAll(async () => {
+  const module = await import('../inbound-lead-service');
+  shouldSkipByDedupe = module.shouldSkipByDedupe;
+  testing = module.__testing;
+});
+
+describe('shouldSkipByDedupe', () => {
+  beforeEach(() => {
+    testing.dedupeCache.clear();
+  });
+
+  it('removes expired entries from the cache', () => {
+    const key = 'tenant:lead';
+    const now = Date.now();
+
+    expect(shouldSkipByDedupe(key, now)).toBe(false);
+
+    const outsideWindow = now + testing.DEDUPE_WINDOW_MS;
+    expect(shouldSkipByDedupe(key, outsideWindow)).toBe(false);
+    expect(testing.dedupeCache.get(key)).toBe(outsideWindow);
+  });
+
+  it('keeps entries inside the dedupe window', () => {
+    const key = 'tenant:lead';
+    const now = Date.now();
+
+    expect(shouldSkipByDedupe(key, now)).toBe(false);
+
+    const insideWindow = now + testing.DEDUPE_WINDOW_MS - 1;
+    expect(shouldSkipByDedupe(key, insideWindow)).toBe(true);
+    expect(testing.dedupeCache.get(key)).toBe(now);
+  });
+});

--- a/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
+++ b/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
@@ -11,8 +11,37 @@ import { emitToTenant } from '../../../lib/socket-registry';
 import { normalizeInboundMessage } from '../utils/normalize';
 
 const DEDUPE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_DEDUPE_CACHE_SIZE = 10_000;
 
 const dedupeCache = new Map<string, number>();
+
+const pruneDedupeCache = (now: number): void => {
+  if (dedupeCache.size === 0) {
+    return;
+  }
+
+  let removedExpiredEntries = 0;
+
+  for (const [key, storedAt] of dedupeCache.entries()) {
+    if (now - storedAt >= DEDUPE_WINDOW_MS) {
+      dedupeCache.delete(key);
+      removedExpiredEntries += 1;
+    }
+  }
+
+  if (dedupeCache.size > MAX_DEDUPE_CACHE_SIZE) {
+    const sizeBefore = dedupeCache.size;
+    dedupeCache.clear();
+    logger.warn(
+      {
+        maxSize: MAX_DEDUPE_CACHE_SIZE,
+        removedExpiredEntries,
+        sizeBefore,
+      },
+      'whatsappInbound.dedupeCache.massivePurge'
+    );
+  }
+};
 const queueCacheByTenant = new Map<string, string>();
 
 interface InboundContactDetails {
@@ -115,7 +144,9 @@ const pickPreferredName = (...values: Array<unknown>): string | null => {
   return null;
 };
 
-const shouldSkipByDedupe = (key: string, now: number): boolean => {
+export const shouldSkipByDedupe = (key: string, now: number): boolean => {
+  pruneDedupeCache(now);
+
   const lastSeen = dedupeCache.get(key);
   if (typeof lastSeen === 'number' && now - lastSeen < DEDUPE_WINDOW_MS) {
     return true;
@@ -261,6 +292,13 @@ const ensureContact = async (
   }
 
   return contact;
+};
+
+export const __testing = {
+  DEDUPE_WINDOW_MS,
+  MAX_DEDUPE_CACHE_SIZE,
+  dedupeCache,
+  pruneDedupeCache,
 };
 
 const ensureTicketForContact = async (


### PR DESCRIPTION
## Summary
- prune stale entries in the inbound WhatsApp dedupe cache and guard against mass growth
- log when a massive purge is required for observability
- cover the dedupe behaviour with focused unit tests

## Testing
- pnpm --filter @ticketz/api exec vitest run src/features/whatsapp-inbound/services/__tests__/inbound-lead-service.dedupe.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e4892193b083328d9235dc29d8b2ca