### PR TITLE
Fix duplicate queue cache declaration and consolidate testing export

### DIFF
--- a/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
+++ b/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
@@ -50,7 +50,6 @@ const pruneDedupeCache = (now: number): void => {
     );
   }
 };
-const queueCacheByTenant = new Map<string, string>();
 
 interface InboundContactDetails {
   phone?: string | null;
@@ -369,8 +368,12 @@ const ensureContact = async (
 export const __testing = {
   DEDUPE_WINDOW_MS,
   MAX_DEDUPE_CACHE_SIZE,
+  DEFAULT_QUEUE_CACHE_TTL_MS,
   dedupeCache,
+  queueCacheByTenant,
   pruneDedupeCache,
+  getDefaultQueueId,
+  ensureTicketForContact,
 };
 
 const ensureTicketForContact = async (
@@ -706,9 +709,3 @@ export const ingestInboundWhatsAppMessage = async (event: InboundWhatsAppEvent) 
   }
 };
 
-export const __testing = {
-  queueCacheByTenant,
-  getDefaultQueueId,
-  ensureTicketForContact,
-  DEFAULT_QUEUE_CACHE_TTL_MS,
-};


### PR DESCRIPTION
## Summary
- remove the duplicate queue cache declaration in the inbound WhatsApp lead service
- consolidate the __testing helper export to include queue cache utilities in a single object

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e48c2bd4988332b2e63bad70c10e09