### PR TITLE
feat: auto-create default WhatsApp queue on outbound send

### DIFF
--- a/apps/api/src/services/ticket-service.ts
+++ b/apps/api/src/services/ticket-service.ts
@@ -109,7 +109,26 @@ const resolveDefaultQueueId = async (tenantId: string): Promise<string> => {
   });
 
   if (!queue) {
-    throw new Error('DEFAULT_QUEUE_NOT_FOUND');
+    const fallbackName = 'Atendimento Geral';
+    const fallbackQueue = await prisma.queue.upsert({
+      where: {
+        tenantId_name: {
+          tenantId,
+          name: fallbackName,
+        },
+      },
+      update: {},
+      create: {
+        tenantId,
+        name: fallbackName,
+        description: 'Fila criada automaticamente para envios de WhatsApp.',
+        color: '#3B82F6',
+        orderIndex: 0,
+      },
+    });
+
+    defaultQueueCache.set(tenantId, fallbackQueue.id);
+    return fallbackQueue.id;
   }
 
   defaultQueueCache.set(tenantId, queue.id);


### PR DESCRIPTION
## Summary
- ensure WhatsApp outbound sends create a default queue when a tenant has none
- extend outbound messaging tests with richer Prisma/contact mocks and coverage for the new queue fallback

## Testing
- pnpm --filter @ticketz/api exec vitest run src/routes/__tests__/messages.outbound.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e48ad0531c8332833df3b3f5298864