### PR TITLE
Fix testing export initialization order

### DIFF
--- a/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
+++ b/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
@@ -365,17 +365,6 @@ const ensureContact = async (
   return contact;
 };
 
-export const __testing = {
-  DEDUPE_WINDOW_MS,
-  MAX_DEDUPE_CACHE_SIZE,
-  DEFAULT_QUEUE_CACHE_TTL_MS,
-  dedupeCache,
-  queueCacheByTenant,
-  pruneDedupeCache,
-  getDefaultQueueId,
-  ensureTicketForContact,
-};
-
 const ensureTicketForContact = async (
   tenantId: string,
   contactId: string,
@@ -449,6 +438,17 @@ const ensureTicketForContact = async (
     });
     return null;
   }
+};
+
+export const __testing = {
+  DEDUPE_WINDOW_MS,
+  MAX_DEDUPE_CACHE_SIZE,
+  DEFAULT_QUEUE_CACHE_TTL_MS,
+  dedupeCache,
+  queueCacheByTenant,
+  pruneDedupeCache,
+  getDefaultQueueId,
+  ensureTicketForContact,
 };
 
 export const ingestInboundWhatsAppMessage = async (event: InboundWhatsAppEvent) => {


### PR DESCRIPTION
## Summary
- move the whatsapp inbound service __testing export so it is evaluated after ensureTicketForContact is defined, avoiding temporal dead zone issues

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e48ff90990833298e0f9df9895006f