### PR TITLE
Fix testing export initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ POST   /api/integrations/whatsapp/events/ack
 > `/api/integrations/whatsapp/instances/:id/status`. As respostas devem refletir os dados reais do broker (sem QR de fallback) e
 > confirmar que a criação/conexão de instâncias funciona end-to-end.
 
+> ✅ Precisa validar o fluxo diretamente da Render shell? Consulte `docs/whatsapp-render-curl-recipes.md` para copiar os comandos
+> `curl` prontos para testar o webhook inbound e o disparo outbound.
+
 #### Webhooks
 ```
 POST   /api/integrations/whatsapp/webhook

--- a/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
+++ b/apps/api/src/features/whatsapp-inbound/services/inbound-lead-service.ts
@@ -365,17 +365,6 @@ const ensureContact = async (
   return contact;
 };
 
-export const __testing = {
-  DEDUPE_WINDOW_MS,
-  MAX_DEDUPE_CACHE_SIZE,
-  DEFAULT_QUEUE_CACHE_TTL_MS,
-  dedupeCache,
-  queueCacheByTenant,
-  pruneDedupeCache,
-  getDefaultQueueId,
-  ensureTicketForContact,
-};
-
 const ensureTicketForContact = async (
   tenantId: string,
   contactId: string,
@@ -449,6 +438,17 @@ const ensureTicketForContact = async (
     });
     return null;
   }
+};
+
+export const __testing = {
+  DEDUPE_WINDOW_MS,
+  MAX_DEDUPE_CACHE_SIZE,
+  DEFAULT_QUEUE_CACHE_TTL_MS,
+  dedupeCache,
+  queueCacheByTenant,
+  pruneDedupeCache,
+  getDefaultQueueId,
+  ensureTicketForContact,
 };
 
 export const ingestInboundWhatsAppMessage = async (event: InboundWhatsAppEvent) => {

--- a/docs/whatsapp-render-curl-recipes.md
+++ b/docs/whatsapp-render-curl-recipes.md
@@ -1,0 +1,86 @@
+# WhatsApp Render Shell cURL Recipes
+
+These snippets help operators validate the WhatsApp webhook (inbound) and outbound delivery flows directly from a Render shell session.
+
+## Prerequisites
+
+1. Open the shell for the API service in Render.
+2. Export the environment variables that mirror the deployment secrets:
+
+```bash
+export API_URL="https://leadengine-corban.onrender.com"            # or the environment specific host
+export WHATSAPP_WEBHOOK_API_KEY="$(cat /etc/secrets/whatsapp_webhook_api_key)"  # adjust path if secrets differ
+export TENANT_ID="demo-tenant"                                     # tenant served by the MVP bypass
+# Optional: only needed if MVP auth bypass is disabled
+# export AUTH_TOKEN="<jwt-token>"
+```
+
+> ℹ️ When `MVP_AUTH_BYPASS=true` (default in demos), the API automatically injects the bypass user and you do **not** need the `Authorization` header. In production environments keep the header enabled.
+
+## Inbound webhook check
+
+Trigger the webhook ingestion with a representative WhatsApp event:
+
+```bash
+curl -X POST "$API_URL/api/integrations/whatsapp/webhook" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $WHATSAPP_WEBHOOK_API_KEY" \
+  -d '{
+    "events": [
+      {
+        "id": "wamid-123",
+        "instanceId": "${TENANT_ID}",
+        "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+        "type": "MESSAGE_INBOUND",
+        "from": {
+          "phone": "+5511999999999",
+          "name": "Maria",
+          "pushName": "Maria C.",
+          "registrations": ["ABC123"]
+        },
+        "message": {
+          "id": "wamid-123",
+          "conversation": "Oi!",
+          "type": "text"
+        },
+        "metadata": {
+          "broker": "baileys",
+          "source": "render-shell"
+        }
+      }
+    ]
+  }'
+```
+
+A successful request returns `{ "ok": true }`. You can tail the worker logs to confirm the event was enqueued and processed:
+
+```bash
+tail -n 200 -f logs/api/current | rg "whatsapp"
+```
+
+## Outbound message check
+
+Dispatch an outbound text message for the same tenant:
+
+```bash
+curl -X POST "$API_URL/api/integrations/whatsapp/messages" \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: $TENANT_ID" \
+  ${AUTH_TOKEN:+-H "Authorization: Bearer $AUTH_TOKEN"} \
+  -d '{
+    "to": "+5511999999999",
+    "message": "Mensagem de teste enviada do Render shell",
+    "previewUrl": false,
+    "externalId": "render-shell-test-$(date +%s)"
+  }'
+```
+
+A successful response returns HTTP `202` with the WhatsApp broker acknowledgement payload. Look for an `ack` of `server` or `delivery` to confirm the broker accepted the message.
+
+> 💡 Need to test media or template flows? Replace the body with the payload documented in `docs/whatsapp-broker-contracts.md` while keeping the same headers.
+
+## Troubleshooting tips
+
+- **401 responses** usually mean the API key or auth token is missing. Double-check the headers exported above.
+- **503 responses** point to broker connectivity problems. Re-run `curl "$API_URL/health"` and inspect the API logs for `whatsapp` errors.
+- **Message queued but not delivered?** Verify the instance connection via `curl "$API_URL/api/integrations/whatsapp/session/status"` and reconnect if needed.


### PR DESCRIPTION
## Summary
- move the whatsapp inbound service __testing export so it is evaluated after ensureTicketForContact is defined, avoiding temporal dead zone issues
- add Render shell curl recipes to README and dedicated doc so operators can validate inbound/outbound flows quickly

## Testing
- pnpm --filter @ticketz/api build

------
https://chatgpt.com/codex/tasks/task_e_68e48ff90990833298e0f9df9895006f