### PR TITLE
feat: add contextual filters to lead inbox

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -144,14 +144,21 @@
   .filter-pill {
     padding: 0.25rem 0.75rem;
     border-radius: 9999px;
+    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
     transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
     transition-duration: 150ms;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     color: var(--text-muted);
     cursor: pointer;
+    outline: none;
+  }
+  .filter-pill:hover {
+    background: color-mix(in oklab, var(--primary) 12%, transparent);
+    color: var(--foreground);
   }
   .filter-pill--active {
-    background: color-mix(in oklab, var(--primary) 20%, transparent);
+    background: color-mix(in oklab, var(--primary) 24%, transparent);
+    border-color: color-mix(in oklab, var(--primary) 65%, transparent);
     color: var(--primary-foreground);
   }
 }

--- a/apps/web/src/features/leads/inbox/components/GlobalFiltersBar.jsx
+++ b/apps/web/src/features/leads/inbox/components/GlobalFiltersBar.jsx
@@ -1,0 +1,282 @@
+import { useMemo, useState } from 'react';
+import { Filter, Plus, Save, SlidersHorizontal, X } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import { Checkbox } from '@/components/ui/checkbox.jsx';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Label } from '@/components/ui/label.jsx';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.jsx';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.jsx';
+import { cn } from '@/lib/utils.js';
+
+import StatusFilter from './StatusFilter.jsx';
+
+const renderOptionLabel = (label, count) => {
+  if (typeof count !== 'number') {
+    return label;
+  }
+  return `${label} (${count})`;
+};
+
+const SavedViewChip = ({ view, isActive, onSelect, onDelete }) => {
+  return (
+    <div className="group flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onSelect(view)}
+        className={cn(
+          'flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          isActive
+            ? 'border-primary/60 bg-primary/10 text-primary-foreground focus-visible:ring-primary'
+            : 'hover:border-primary/40 hover:text-foreground focus-visible:ring-ring'
+        )}
+      >
+        <span>{view.name}</span>
+        <Badge variant={isActive ? 'default' : 'outline'} className="px-2 text-[10px]">
+          {view.count ?? 0}
+        </Badge>
+      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => onDelete(view)}
+            className="rounded-full p-1 text-muted-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            aria-label={`Remover visão ${view.name}`}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Remover visão salva</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
+export const GlobalFiltersBar = ({
+  filters,
+  onUpdateFilters,
+  onResetFilters,
+  queueOptions,
+  windowOptions,
+  savedViews,
+  activeViewId,
+  onSelectSavedView,
+  onSaveCurrentView,
+  onDeleteSavedView,
+  canSaveView,
+  viewLimit,
+}) => {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const queueLabel = useMemo(() => {
+    const option = queueOptions.find((item) => item.value === filters.queue);
+    return option?.label ?? 'Todas as filas';
+  }, [filters.queue, queueOptions]);
+
+  const windowLabel = useMemo(() => {
+    const option = windowOptions.find((item) => item.value === filters.timeWindow);
+    return option?.label ?? 'Qualquer período';
+  }, [filters.timeWindow, windowOptions]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+          <Filter className="h-4 w-4" />
+          <span>Filtro rápido</span>
+        </div>
+
+        <StatusFilter
+          value={filters.status}
+          onChange={(status) => onUpdateFilters({ status })}
+        />
+
+        <Select
+          value={filters.queue}
+          onValueChange={(value) => onUpdateFilters({ queue: value })}
+        >
+          <SelectTrigger className="h-9 min-w-[180px] text-xs">
+            <SelectValue placeholder="Fila">
+              {renderOptionLabel(queueLabel, queueOptions.find((item) => item.value === filters.queue)?.count)}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {queueOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {renderOptionLabel(option.label, option.count)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.timeWindow}
+          onValueChange={(value) => onUpdateFilters({ timeWindow: value })}
+        >
+          <SelectTrigger className="h-9 min-w-[160px] text-xs">
+            <SelectValue placeholder="Janela">
+              {windowLabel}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {windowOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Drawer open={drawerOpen} onOpenChange={setDrawerOpen}>
+          <DrawerTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-2 text-xs">
+              <SlidersHorizontal className="h-4 w-4" /> Mais filtros
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent className="sm:max-w-md">
+            <DrawerHeader>
+              <DrawerTitle>Filtros avançados</DrawerTitle>
+              <p className="text-sm text-muted-foreground">
+                Ajuste critérios menos frequentes. As preferências ficam salvas para o seu usuário.
+              </p>
+            </DrawerHeader>
+
+            <div className="flex flex-col gap-4 px-4 pb-4">
+              <div className="space-y-2">
+                <Label htmlFor="inbox-search">Buscar por nome, CPF ou telefone</Label>
+                <Input
+                  id="inbox-search"
+                  placeholder="Digite um termo de busca"
+                  value={filters.search}
+                  onChange={(event) => onUpdateFilters({ search: event.target.value })}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="inbox-min-score">Score mínimo</Label>
+                  <Input
+                    id="inbox-min-score"
+                    type="number"
+                    inputMode="numeric"
+                    min="0"
+                    max="1000"
+                    placeholder="0"
+                    value={filters.minScore ?? ''}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      onUpdateFilters({ minScore: value === '' ? null : Number(value) });
+                    }}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="inbox-min-margin">Margem mínima (R$)</Label>
+                  <Input
+                    id="inbox-min-margin"
+                    type="number"
+                    inputMode="decimal"
+                    min="0"
+                    step="100"
+                    placeholder="0"
+                    value={filters.minMargin ?? ''}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      onUpdateFilters({ minMargin: value === '' ? null : Number(value) });
+                    }}
+                  />
+                </div>
+              </div>
+
+              <label className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Checkbox
+                  checked={filters.hasPhoneOnly}
+                  onCheckedChange={(checked) =>
+                    onUpdateFilters({ hasPhoneOnly: Boolean(checked) })
+                  }
+                />
+                Exibir apenas leads com telefone válido
+              </label>
+            </div>
+
+            <DrawerFooter>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <DrawerClose asChild>
+                  <Button variant="ghost" size="sm">
+                    Fechar
+                  </Button>
+                </DrawerClose>
+                <Button variant="outline" size="sm" onClick={onResetFilters}>
+                  Limpar filtros
+                </Button>
+              </div>
+            </DrawerFooter>
+          </DrawerContent>
+        </Drawer>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+          <Save className="h-4 w-4" />
+          <span>Views salvas</span>
+        </div>
+
+        {savedViews.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Salve uma combinação de filtros para acompanhar filas ou SLAs específicos.
+          </p>
+        ) : (
+          savedViews.map((view) => (
+            <SavedViewChip
+              key={view.id}
+              view={view}
+              isActive={activeViewId === view.id}
+              onSelect={onSelectSavedView}
+              onDelete={onDeleteSavedView}
+            />
+          ))
+        )}
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-2 text-xs"
+                onClick={onSaveCurrentView}
+                disabled={!canSaveView}
+              >
+                <Plus className="h-4 w-4" /> Salvar visão atual
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {canSaveView
+              ? `Você pode salvar até ${viewLimit} visões personalizadas.`
+              : 'Limite de visões atingido ou filtros já salvos.'}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export default GlobalFiltersBar;

--- a/apps/web/src/features/leads/inbox/components/InboxActions.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxActions.jsx
@@ -1,10 +1,10 @@
 import { Download, Loader2, RefreshCcw, Sparkles } from 'lucide-react';
 
 import { Button } from '@/components/ui/button.jsx';
-import { ButtonGroup } from '@/components/ui/button-group.jsx';
 import NoticeBanner from '@/components/ui/notice-banner.jsx';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.jsx';
 import { cn } from '@/lib/utils.js';
+import { Badge } from '@/components/ui/badge.jsx';
 
 const formatCountdown = (seconds) => {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds)) {
@@ -25,6 +25,14 @@ export const InboxActions = ({
   lastUpdatedAt,
 }) => {
   const countdownLabel = formatCountdown(autoRefreshSeconds);
+  const primaryRefreshLabel = loading ? 'Sincronizando em tempo real' : 'Atualização automática';
+  const secondaryRefreshLabel = countdownLabel ?? 'A cada 15 segundos';
+  const lastUpdatedLabel = lastUpdatedAt
+    ? `Última atualização às ${lastUpdatedAt.toLocaleTimeString('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      })}`
+    : null;
 
   return (
     <div className="space-y-4">
@@ -48,11 +56,27 @@ export const InboxActions = ({
         </NoticeBanner>
       ) : null}
 
-      <ButtonGroup className="justify-between">
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-          {countdownLabel ? countdownLabel : 'Atualização contínua a cada 15s'}
+      <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/20 p-4 text-xs">
+        <div className="flex flex-wrap items-center justify-between gap-3 text-muted-foreground">
+          <Badge
+            variant="outline"
+            className={cn(
+              'flex items-center gap-2 border-primary/40 bg-primary/5 text-foreground',
+              loading && 'border-primary bg-primary/10'
+            )}
+          >
+            {loading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCcw className="h-3.5 w-3.5" />
+            )}
+            <span className="font-medium text-xs text-foreground">{primaryRefreshLabel}</span>
+            <span className="text-[10px] text-muted-foreground">{secondaryRefreshLabel}</span>
+          </Badge>
+          {lastUpdatedLabel ? <span>{lastUpdatedLabel}</span> : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -66,13 +90,13 @@ export const InboxActions = ({
                 {loading ? 'Sincronizando…' : 'Atualizar agora'}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Atualização automática a cada 15 segundos.</TooltipContent>
+            <TooltipContent>Atualização automática acontece em segundo plano.</TooltipContent>
           </Tooltip>
           <Button variant="outline" size="sm" onClick={onExport} className="gap-2">
             <Download className="h-4 w-4" /> Exportar CSV
           </Button>
         </div>
-      </ButtonGroup>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertCircle, Trophy, XCircle } from 'lucide-react';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx';
@@ -9,7 +9,282 @@ import useInboxLiveUpdates from '@/features/whatsapp-inbound/sockets/useInboxLiv
 import InboxHeader from './InboxHeader.jsx';
 import InboxActions from './InboxActions.jsx';
 import InboxList from './InboxList.jsx';
-import StatusFilter from './StatusFilter.jsx';
+import GlobalFiltersBar from './GlobalFiltersBar.jsx';
+
+const SAVED_FILTERS_STORAGE_KEY = 'leadengine_inbox_filters_v1';
+const SAVED_VIEWS_STORAGE_KEY = 'leadengine_inbox_saved_views_v1';
+const SAVED_VIEWS_LIMIT = 10;
+const THIRTY_DAYS_MS = 1000 * 60 * 60 * 24 * 30;
+const NO_QUEUE_VALUE = '__none__';
+
+const defaultFilters = {
+  status: 'all',
+  queue: 'all',
+  timeWindow: 'any',
+  search: '',
+  minScore: null,
+  minMargin: null,
+  hasPhoneOnly: false,
+};
+
+const normalizeFilters = (value) => {
+  if (!value || typeof value !== 'object') {
+    return { ...defaultFilters };
+  }
+
+  return {
+    status: value.status && typeof value.status === 'string' ? value.status : defaultFilters.status,
+    queue: value.queue && typeof value.queue === 'string' ? value.queue : defaultFilters.queue,
+    timeWindow:
+      value.timeWindow && typeof value.timeWindow === 'string'
+        ? value.timeWindow
+        : defaultFilters.timeWindow,
+    search: typeof value.search === 'string' ? value.search : defaultFilters.search,
+    minScore:
+      typeof value.minScore === 'number' && Number.isFinite(value.minScore)
+        ? value.minScore
+        : null,
+    minMargin:
+      typeof value.minMargin === 'number' && Number.isFinite(value.minMargin)
+        ? value.minMargin
+        : null,
+    hasPhoneOnly: Boolean(value.hasPhoneOnly),
+  };
+};
+
+const serializeFilters = (value) => {
+  const filters = normalizeFilters(value);
+  return JSON.stringify([
+    filters.status,
+    filters.queue,
+    filters.timeWindow,
+    filters.search.trim().toLowerCase(),
+    filters.minScore ?? null,
+    filters.minMargin ?? null,
+    filters.hasPhoneOnly,
+  ]);
+};
+
+const ensureDate = (input) => {
+  if (!input) return null;
+
+  if (input instanceof Date && !Number.isNaN(input.getTime())) {
+    return input;
+  }
+
+  const date = new Date(input);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const resolveReferenceDate = (allocation) => {
+  const candidates = [
+    allocation?.lastMessageAt,
+    allocation?.lastInteractionAt,
+    allocation?.updatedAt,
+    allocation?.createdAt,
+    allocation?.allocatedAt,
+    allocation?.firstMessageAt,
+  ];
+
+  for (const candidate of candidates) {
+    const date = ensureDate(candidate);
+    if (date) {
+      return date;
+    }
+  }
+
+  return null;
+};
+
+const matchesWindow = (date, window) => {
+  if (window === 'any') {
+    return true;
+  }
+
+  if (!date) {
+    return false;
+  }
+
+  const now = new Date();
+  const diffMs = Math.abs(now.getTime() - date.getTime());
+  const diffDays = diffMs / (1000 * 60 * 60 * 24);
+
+  switch (window) {
+    case 'today':
+      return date.toDateString() === now.toDateString();
+    case 'last3d':
+      return diffDays <= 3;
+    case 'last7d':
+      return diffDays <= 7;
+    case 'older':
+      return diffDays > 7;
+    default:
+      return true;
+  }
+};
+
+const resolveQueueValue = (allocation) => {
+  const label =
+    allocation?.queue?.name ??
+    allocation?.queueName ??
+    allocation?.queue_label ??
+    allocation?.queue ??
+    null;
+  if (!label) {
+    return { value: NO_QUEUE_VALUE, label: 'Sem fila definida' };
+  }
+  return { value: String(label), label: String(label) };
+};
+
+const filterAllocationsWithFilters = (allocations, rawFilters) => {
+  const filters = normalizeFilters(rawFilters);
+  const searchTerm = filters.search.trim().toLowerCase();
+
+  return allocations.filter((allocation) => {
+    if (filters.status !== 'all' && allocation.status !== filters.status) {
+      return false;
+    }
+
+    const { value: queueValue } = resolveQueueValue(allocation);
+    if (filters.queue !== 'all' && queueValue !== filters.queue) {
+      return false;
+    }
+
+    if (filters.hasPhoneOnly) {
+      const phone = typeof allocation.phone === 'string' ? allocation.phone.replace(/\D/g, '') : '';
+      if (!phone) {
+        return false;
+      }
+    }
+
+    if (typeof filters.minScore === 'number') {
+      const score = typeof allocation.score === 'number' ? allocation.score : null;
+      if (score === null || score < filters.minScore) {
+        return false;
+      }
+    }
+
+    if (typeof filters.minMargin === 'number') {
+      const margin =
+        typeof allocation.netMargin === 'number'
+          ? allocation.netMargin
+          : typeof allocation.margin === 'number'
+            ? allocation.margin
+            : null;
+      if (margin === null || margin < filters.minMargin) {
+        return false;
+      }
+    }
+
+    if (!matchesWindow(resolveReferenceDate(allocation), filters.timeWindow)) {
+      return false;
+    }
+
+    if (searchTerm) {
+      const haystackParts = [
+        allocation.fullName,
+        allocation.document,
+        allocation.phone,
+      ];
+      if (Array.isArray(allocation.registrations)) {
+        haystackParts.push(allocation.registrations.join(' '));
+      }
+      const haystack = haystackParts
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(searchTerm)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+};
+
+const TIME_WINDOW_OPTIONS = [
+  { value: 'any', label: 'Qualquer período' },
+  { value: 'today', label: 'Hoje' },
+  { value: 'last3d', label: 'Últimos 3 dias' },
+  { value: 'last7d', label: 'Últimos 7 dias' },
+  { value: 'older', label: 'Mais antigos que 7 dias' },
+];
+
+const loadStoredFilters = () => {
+  if (typeof window === 'undefined') {
+    return { ...defaultFilters };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SAVED_FILTERS_STORAGE_KEY);
+    if (!raw) {
+      return { ...defaultFilters };
+    }
+    return normalizeFilters(JSON.parse(raw));
+  } catch (error) {
+    console.warn('Não foi possível restaurar filtros da Inbox', error);
+    return { ...defaultFilters };
+  }
+};
+
+const normalizeSavedView = (view) => {
+  if (!view || typeof view !== 'object') {
+    return null;
+  }
+
+  const id = typeof view.id === 'string' ? view.id : null;
+  const name = typeof view.name === 'string' ? view.name.trim() : '';
+
+  if (!id || !name) {
+    return null;
+  }
+
+  const createdAt =
+    typeof view.createdAt === 'number' && Number.isFinite(view.createdAt)
+      ? view.createdAt
+      : Date.now();
+  const lastUsedAt =
+    typeof view.lastUsedAt === 'number' && Number.isFinite(view.lastUsedAt)
+      ? view.lastUsedAt
+      : null;
+
+  return {
+    id,
+    name,
+    filters: normalizeFilters(view.filters),
+    createdAt,
+    lastUsedAt,
+  };
+};
+
+const loadStoredViews = () => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SAVED_VIEWS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const now = Date.now();
+    return parsed
+      .map(normalizeSavedView)
+      .filter(Boolean)
+      .filter((view) => {
+        const reference = view.lastUsedAt ?? view.createdAt;
+        return !reference || now - reference <= THIRTY_DAYS_MS;
+      });
+  } catch (error) {
+    console.warn('Não foi possível restaurar views salvas da Inbox', error);
+    return [];
+  }
+};
 
 const statusMetrics = [
   { key: 'total', label: 'Total recebido' },
@@ -30,7 +305,16 @@ export const LeadInbox = ({
   const agreementId = selectedAgreement?.id;
   const campaignId = campaign?.id;
 
-  const [statusFilter, setStatusFilter] = useState('all');
+  const initialFilters = useMemo(() => loadStoredFilters(), []);
+  const initialViews = useMemo(() => loadStoredViews(), []);
+
+  const [filters, setFilters] = useState(initialFilters);
+  const [savedViews, setSavedViews] = useState(initialViews);
+  const [activeViewId, setActiveViewId] = useState(() => {
+    const serialized = serializeFilters(initialFilters);
+    const matchingView = initialViews.find((view) => serializeFilters(view.filters) === serialized);
+    return matchingView?.id ?? null;
+  });
   const [autoRefreshSeconds, setAutoRefreshSeconds] = useState(null);
 
   const {
@@ -54,14 +338,66 @@ export const LeadInbox = ({
     },
   });
 
+  useEffect(() => {
+    setSavedViews((current) => {
+      const now = Date.now();
+      const pruned = current.filter((view) => {
+        const reference = view.lastUsedAt ?? view.createdAt;
+        return !reference || now - reference <= THIRTY_DAYS_MS;
+      });
+      return pruned.length === current.length ? current : pruned;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(SAVED_FILTERS_STORAGE_KEY, JSON.stringify(filters));
+    } catch (error) {
+      console.warn('Não foi possível persistir filtros da Inbox', error);
+    }
+  }, [filters]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(SAVED_VIEWS_STORAGE_KEY, JSON.stringify(savedViews));
+    } catch (error) {
+      console.warn('Não foi possível persistir views salvas da Inbox', error);
+    }
+  }, [savedViews]);
+
+  const previousContextRef = useRef({
+    agreementId: agreementId ?? null,
+    campaignId: campaignId ?? null,
+  });
+
+  useEffect(() => {
+    const previous = previousContextRef.current;
+    const current = {
+      agreementId: agreementId ?? null,
+      campaignId: campaignId ?? null,
+    };
+
+    const hasChanged =
+      previous.agreementId !== current.agreementId || previous.campaignId !== current.campaignId;
+
+    if (hasChanged && (previous.agreementId !== null || previous.campaignId !== null)) {
+      setFilters({ ...defaultFilters });
+      setActiveViewId(null);
+    }
+
+    previousContextRef.current = current;
+  }, [agreementId, campaignId]);
+
   const stageIndex = onboarding?.stages?.findIndex((stage) => stage.id === 'inbox') ?? onboarding?.activeStep ?? 3;
   const totalStages = onboarding?.stages?.length ?? 0;
   const stepNumber = stageIndex >= 0 ? stageIndex + 1 : 4;
   const stepLabel = totalStages ? `Passo ${Math.min(stepNumber, totalStages)} de ${totalStages}` : `Passo ${stepNumber}`;
-
-  useEffect(() => {
-    setStatusFilter('all');
-  }, [agreementId, campaignId]);
 
   useEffect(() => {
     if (!nextRefreshAt) {
@@ -79,12 +415,136 @@ export const LeadInbox = ({
     return () => window.clearInterval(interval);
   }, [nextRefreshAt]);
 
-  const filteredAllocations = useMemo(() => {
-    if (statusFilter === 'all') {
-      return allocations;
+  const queueOptions = useMemo(() => {
+    const counts = new Map();
+
+    allocations.forEach((allocation) => {
+      const { value, label } = resolveQueueValue(allocation);
+      if (!counts.has(value)) {
+        counts.set(value, { value, label, count: 0 });
+      }
+      counts.get(value).count += 1;
+    });
+
+    const entries = Array.from(counts.values()).sort((a, b) =>
+      a.label.localeCompare(b.label, 'pt-BR')
+    );
+
+    return [
+      { value: 'all', label: 'Todas as filas', count: allocations.length },
+      ...entries,
+    ];
+  }, [allocations]);
+
+  const filteredAllocations = useMemo(
+    () => filterAllocationsWithFilters(allocations, filters),
+    [allocations, filters]
+  );
+
+  const savedViewsWithCount = useMemo(
+    () =>
+      savedViews.map((view) => ({
+        ...view,
+        count: filterAllocationsWithFilters(allocations, view.filters).length,
+      })),
+    [allocations, savedViews]
+  );
+
+  const serializedFilters = useMemo(() => serializeFilters(filters), [filters]);
+
+  const matchingSavedView = useMemo(
+    () => savedViews.find((view) => serializeFilters(view.filters) === serializedFilters) ?? null,
+    [savedViews, serializedFilters]
+  );
+
+  useEffect(() => {
+    if (matchingSavedView && activeViewId !== matchingSavedView.id) {
+      setActiveViewId(matchingSavedView.id);
     }
-    return allocations.filter((allocation) => allocation.status === statusFilter);
-  }, [allocations, statusFilter]);
+    if (!matchingSavedView && activeViewId) {
+      setActiveViewId(null);
+    }
+  }, [activeViewId, matchingSavedView]);
+
+  const canSaveCurrentView = savedViews.length < SAVED_VIEWS_LIMIT && !matchingSavedView;
+
+  const handleUpdateFilters = useCallback(
+    (partial) => {
+      setFilters((current) => {
+        const next = normalizeFilters({ ...current, ...partial });
+        if (activeViewId) {
+          const activeView = savedViews.find((view) => view.id === activeViewId);
+          if (!activeView || serializeFilters(activeView.filters) !== serializeFilters(next)) {
+            setActiveViewId(null);
+          }
+        }
+        return next;
+      });
+    },
+    [activeViewId, savedViews]
+  );
+
+  const handleResetFilters = useCallback(() => {
+    setFilters({ ...defaultFilters });
+    setActiveViewId(null);
+  }, []);
+
+  const handleSelectSavedView = useCallback((view) => {
+    setFilters(normalizeFilters(view.filters));
+    setActiveViewId(view.id);
+    setSavedViews((current) =>
+      current.map((item) =>
+        item.id === view.id ? { ...item, lastUsedAt: Date.now() } : item
+      )
+    );
+  }, []);
+
+  const handleSaveCurrentView = useCallback(() => {
+    if (!canSaveCurrentView) {
+      if (matchingSavedView) {
+        setActiveViewId(matchingSavedView.id);
+      }
+      return;
+    }
+
+    const defaultName = `Visão ${savedViews.length + 1}`;
+    const input = typeof window !== 'undefined' ? window.prompt('Nome da visão', defaultName) : null;
+    if (!input) {
+      return;
+    }
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const newView = {
+      id: `view-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      name: trimmed.slice(0, 48),
+      filters: normalizeFilters(filters),
+      createdAt: Date.now(),
+      lastUsedAt: Date.now(),
+    };
+
+    setSavedViews((current) => {
+      const next = [...current, newView];
+      if (next.length > SAVED_VIEWS_LIMIT) {
+        next.shift();
+      }
+      return next;
+    });
+    setActiveViewId(newView.id);
+  }, [canSaveCurrentView, filters, matchingSavedView, savedViews.length]);
+
+  const handleDeleteSavedView = useCallback(
+    (view) => {
+      setSavedViews((current) => current.filter((item) => item.id !== view.id));
+      if (activeViewId === view.id) {
+        setActiveViewId(null);
+      }
+    },
+    [activeViewId]
+  );
 
   const openWhatsApp = (allocation) => {
     const phone = allocation.phone?.replace(/\D/g, '');
@@ -119,16 +579,31 @@ export const LeadInbox = ({
             ))}
           </div>
         </CardHeader>
-        <CardContent className="space-y-4">
-         <InboxActions
+        <CardContent className="space-y-6">
+          <GlobalFiltersBar
+            filters={filters}
+            onUpdateFilters={handleUpdateFilters}
+            onResetFilters={handleResetFilters}
+            queueOptions={queueOptions}
+            windowOptions={TIME_WINDOW_OPTIONS}
+            savedViews={savedViewsWithCount}
+            activeViewId={activeViewId}
+            onSelectSavedView={handleSelectSavedView}
+            onSaveCurrentView={handleSaveCurrentView}
+            onDeleteSavedView={handleDeleteSavedView}
+            canSaveView={canSaveCurrentView}
+            viewLimit={SAVED_VIEWS_LIMIT}
+          />
+
+          <InboxActions
             loading={loading}
             onRefresh={refresh}
             onExport={() => {
               const params = new URLSearchParams();
               if (campaignId) params.set('campaignId', campaignId);
               if (agreementId) params.set('agreementId', agreementId);
-              if (statusFilter !== 'all') {
-                params.set('status', statusFilter);
+              if (filters.status !== 'all') {
+                params.set('status', filters.status);
               }
               if (campaign?.instanceId) {
                 params.set('instanceId', campaign.instanceId);
@@ -151,10 +626,6 @@ export const LeadInbox = ({
               Tempo real indisponível: {connectionError}. Continuamos monitorando via atualização automática.
             </NoticeBanner>
           ) : null}
-
-          <div className="flex items-center justify-between">
-            <StatusFilter value={statusFilter} onChange={setStatusFilter} />
-          </div>
 
           {error ? (
             <NoticeBanner variant="danger" icon={<AlertCircle className="h-4 w-4" />}>

--- a/apps/web/src/features/leads/inbox/components/StatusFilter.jsx
+++ b/apps/web/src/features/leads/inbox/components/StatusFilter.jsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils.js';
+
 const STATUS_ORDER = ['all', 'contacted', 'won', 'lost'];
 
 const STATUS_LABEL = {
@@ -8,13 +10,17 @@ const STATUS_LABEL = {
 };
 
 export const StatusFilter = ({ value, onChange }) => (
-  <div className="inline-flex rounded-full bg-[rgba(148,163,184,0.12)] p-1 text-xs text-muted-foreground">
+  <div className="inline-flex items-center gap-1 rounded-full bg-[rgba(148,163,184,0.12)] p-1 text-xs text-muted-foreground">
     {STATUS_ORDER.map((status) => (
       <button
         key={status}
         type="button"
         onClick={() => onChange(status)}
-        className={`filter-pill ${value === status ? 'filter-pill--active' : ''}`}
+        className={cn(
+          'filter-pill focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          value === status && 'filter-pill--active focus-visible:ring-primary'
+        )}
+        aria-pressed={value === status}
       >
         {STATUS_LABEL[status]}
       </button>


### PR DESCRIPTION
## Summary
- add a global filters bar with queue/window selectors, saved views and an advanced filter drawer for the lead inbox
- persist inbox filters locally, expose saved view counts and update the list filtering logic to respect the new criteria
- refresh the inbox actions panel and status pills to highlight auto-refresh status with improved accessibility feedback

## Testing
- pnpm -C apps/web lint *(fails: existing no-unused-vars error in apps/web/src/features/whatsapp/WhatsAppConnect.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e5203c5b888332b93f217085cfb082