### PR TITLE
feat: add configurable inbox split layout and preferences

### DIFF
--- a/apps/api/src/data/user-preferences-store.ts
+++ b/apps/api/src/data/user-preferences-store.ts
@@ -1,0 +1,82 @@
+export type InboxListPosition = 'left' | 'right';
+
+export interface UserPreferencesRecord {
+  inboxListPosition: InboxListPosition;
+  inboxListWidth: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const MIN_INBOX_LIST_WIDTH = 320;
+export const MAX_INBOX_LIST_WIDTH = 560;
+export const DEFAULT_INBOX_LIST_WIDTH = 384;
+export const DEFAULT_INBOX_LIST_POSITION: InboxListPosition = 'left';
+
+const clampWidth = (width: number): number => {
+  if (!Number.isFinite(width)) {
+    return DEFAULT_INBOX_LIST_WIDTH;
+  }
+  if (width < MIN_INBOX_LIST_WIDTH) {
+    return MIN_INBOX_LIST_WIDTH;
+  }
+  if (width > MAX_INBOX_LIST_WIDTH) {
+    return MAX_INBOX_LIST_WIDTH;
+  }
+  return Math.round(width);
+};
+
+const createDefaultPreferences = (): UserPreferencesRecord => {
+  const now = new Date().toISOString();
+  return {
+    inboxListPosition: DEFAULT_INBOX_LIST_POSITION,
+    inboxListWidth: DEFAULT_INBOX_LIST_WIDTH,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+const userPreferencesStore = new Map<string, UserPreferencesRecord>();
+
+export const getUserPreferences = (userId: string): UserPreferencesRecord => {
+  const existing = userPreferencesStore.get(userId);
+  if (existing) {
+    return { ...existing };
+  }
+
+  const defaults = createDefaultPreferences();
+  userPreferencesStore.set(userId, defaults);
+  return { ...defaults };
+};
+
+export const updateUserPreferences = (
+  userId: string,
+  patch: Partial<Pick<UserPreferencesRecord, 'inboxListPosition' | 'inboxListWidth'>>
+): UserPreferencesRecord => {
+  const current = getUserPreferences(userId);
+  const nextPosition = patch.inboxListPosition === 'right' ? 'right' : current.inboxListPosition;
+  const nextWidth =
+    typeof patch.inboxListWidth === 'number'
+      ? clampWidth(patch.inboxListWidth)
+      : current.inboxListWidth;
+
+  const updated: UserPreferencesRecord = {
+    inboxListPosition: nextPosition,
+    inboxListWidth: nextWidth,
+    createdAt: current.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+
+  userPreferencesStore.set(userId, updated);
+  return { ...updated };
+};
+
+export const resetUserPreferencesStore = (): void => {
+  userPreferencesStore.clear();
+};
+
+export const getAllUserPreferences = (): Record<string, UserPreferencesRecord> => {
+  return Array.from(userPreferencesStore.entries()).reduce<Record<string, UserPreferencesRecord>>((acc, [key, value]) => {
+    acc[key] = { ...value };
+    return acc;
+  }, {});
+};

--- a/apps/api/src/routes/preferences.ts
+++ b/apps/api/src/routes/preferences.ts
@@ -1,0 +1,156 @@
+import { Router, type Request, type Response } from 'express';
+import { z, ZodError } from 'zod';
+
+import { asyncHandler } from '../middleware/error-handler';
+import { respondWithValidationError } from '../utils/http-validation';
+import {
+  DEFAULT_INBOX_LIST_POSITION,
+  DEFAULT_INBOX_LIST_WIDTH,
+  MAX_INBOX_LIST_WIDTH,
+  MIN_INBOX_LIST_WIDTH,
+  getUserPreferences,
+  updateUserPreferences,
+} from '../data/user-preferences-store';
+
+const router = Router();
+
+const widthSchema = z
+  .preprocess((value) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : value;
+    }
+    return value;
+  }, z.number().min(MIN_INBOX_LIST_WIDTH).max(MAX_INBOX_LIST_WIDTH))
+  .optional();
+
+const updatePreferencesSchema = z
+  .object({
+    inboxListPosition: z.enum(['left', 'right']).optional(),
+    inboxListWidth: widthSchema,
+  })
+  .strict();
+
+const ensureUser = (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({
+      success: false,
+      error: {
+        code: 'UNAUTHENTICATED',
+        message: 'Autenticação obrigatória.',
+      },
+    });
+    return null;
+  }
+  return req.user;
+};
+
+router.get(
+  '/preferences',
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = ensureUser(req, res);
+    if (!user) {
+      return;
+    }
+
+    const preferences = getUserPreferences(user.id);
+    res.json({
+      success: true,
+      data: preferences,
+    });
+  })
+);
+
+router.get(
+  '/users/:userId/preferences',
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = ensureUser(req, res);
+    if (!user) {
+      return;
+    }
+
+    const { userId } = req.params;
+    if (user.id !== userId && user.role !== 'ADMIN') {
+      res.status(403).json({
+        success: false,
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Você não tem permissão para visualizar as preferências desse usuário.',
+        },
+      });
+      return;
+    }
+
+    const preferences = getUserPreferences(userId);
+    res.json({
+      success: true,
+      data: preferences,
+    });
+  })
+);
+
+router.patch(
+  '/users/:userId/preferences',
+  asyncHandler(async (req: Request, res: Response) => {
+    const user = ensureUser(req, res);
+    if (!user) {
+      return;
+    }
+
+    const { userId } = req.params;
+    if (user.id !== userId && user.role !== 'ADMIN') {
+      res.status(403).json({
+        success: false,
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Você não tem permissão para atualizar as preferências desse usuário.',
+        },
+      });
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = updatePreferencesSchema.parse(req.body ?? {});
+    } catch (error) {
+      if (error instanceof ZodError) {
+        respondWithValidationError(res, error.issues);
+        return;
+      }
+      throw error;
+    }
+
+    if (parsed.inboxListPosition === undefined && parsed.inboxListWidth === undefined) {
+      const current = getUserPreferences(userId);
+      res.json({
+        success: true,
+        data: current,
+        meta: { unchanged: true },
+      });
+      return;
+    }
+
+    const updated = updateUserPreferences(userId, parsed);
+    res.json({
+      success: true,
+      data: updated,
+    });
+  })
+);
+
+router.get(
+  '/preferences/defaults',
+  (_req: Request, res: Response) => {
+    res.json({
+      success: true,
+      data: {
+        inboxListPosition: DEFAULT_INBOX_LIST_POSITION,
+        inboxListWidth: DEFAULT_INBOX_LIST_WIDTH,
+        minInboxListWidth: MIN_INBOX_LIST_WIDTH,
+        maxInboxListWidth: MAX_INBOX_LIST_WIDTH,
+      },
+    });
+  }
+);
+
+export { router as preferencesRouter };

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -29,6 +29,7 @@ import { ticketMessagesRouter } from './routes/messages.ticket';
 import { contactMessagesRouter } from './routes/messages.contact';
 import { whatsappMessagesRouter } from './routes/integrations/whatsapp.messages';
 import { registerSocketConnectionHandlers } from './socket/connection-handlers';
+import { preferencesRouter } from './routes/preferences';
 
 if (process.env.NODE_ENV !== 'production') {
   dotenv.config();
@@ -326,6 +327,7 @@ app.use('/api', authMiddleware, whatsappMessagesRouter);
 app.use('/api/integrations', authMiddleware, integrationsRouter);
 app.use('/api/campaigns', authMiddleware, requireTenant, campaignsRouter);
 app.use('/api/queues', authMiddleware, requireTenant, queuesRouter);
+app.use('/api', authMiddleware, preferencesRouter);
 
 // Socket.IO para tempo real
 io.use((socket, next) => {

--- a/apps/web/src/features/chat/ChatCommandCenter.jsx
+++ b/apps/web/src/features/chat/ChatCommandCenter.jsx
@@ -161,6 +161,7 @@ export const ChatCommandCenter = ({ tenantId: tenantIdProp, currentUser }) => {
 
   return (
     <InboxAppShell
+      currentUser={currentUser}
       sidebar={
         <QueueList
           tickets={controller.tickets}

--- a/apps/web/src/features/chat/api/useInboxLayoutPreferences.js
+++ b/apps/web/src/features/chat/api/useInboxLayoutPreferences.js
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '@/lib/api.js';
+
+export const MIN_INBOX_LIST_WIDTH = 320;
+export const MAX_INBOX_LIST_WIDTH = 560;
+export const DEFAULT_INBOX_LIST_WIDTH = 384;
+export const DEFAULT_INBOX_LAYOUT_PREFERENCES = Object.freeze({
+  inboxListPosition: 'left',
+  inboxListWidth: DEFAULT_INBOX_LIST_WIDTH,
+});
+
+export const INBOX_LAYOUT_PREFERENCES_QUERY_KEY = ['inbox', 'layout', 'preferences'];
+
+const sanitizePreferences = (raw) => {
+  if (!raw || typeof raw !== 'object') {
+    return { ...DEFAULT_INBOX_LAYOUT_PREFERENCES };
+  }
+
+  const position = raw.inboxListPosition === 'right' ? 'right' : 'left';
+
+  let width = Number(raw.inboxListWidth);
+  if (!Number.isFinite(width)) {
+    width = DEFAULT_INBOX_LIST_WIDTH;
+  }
+  width = Math.min(Math.max(width, MIN_INBOX_LIST_WIDTH), MAX_INBOX_LIST_WIDTH);
+
+  return {
+    inboxListPosition: position,
+    inboxListWidth: width,
+    updatedAt: typeof raw.updatedAt === 'string' ? raw.updatedAt : undefined,
+  };
+};
+
+export const useInboxLayoutPreferences = ({ enabled = true } = {}) =>
+  useQuery({
+    queryKey: INBOX_LAYOUT_PREFERENCES_QUERY_KEY,
+    enabled,
+    queryFn: async () => {
+      const response = await apiGet('/api/preferences');
+      return sanitizePreferences(response?.data);
+    },
+    placeholderData: DEFAULT_INBOX_LAYOUT_PREFERENCES,
+  });
+
+export default useInboxLayoutPreferences;

--- a/apps/web/src/features/chat/api/useUpdateInboxLayoutPreferences.js
+++ b/apps/web/src/features/chat/api/useUpdateInboxLayoutPreferences.js
@@ -1,0 +1,82 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiPatch } from '@/lib/api.js';
+import {
+  DEFAULT_INBOX_LAYOUT_PREFERENCES,
+  INBOX_LAYOUT_PREFERENCES_QUERY_KEY,
+  MIN_INBOX_LIST_WIDTH,
+  MAX_INBOX_LIST_WIDTH,
+} from './useInboxLayoutPreferences.js';
+
+const clampWidth = (value) => {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(Math.max(Math.round(value), MIN_INBOX_LIST_WIDTH), MAX_INBOX_LIST_WIDTH);
+};
+
+export const useUpdateInboxLayoutPreferences = ({ userId } = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (partial) => {
+      if (!userId) {
+        throw new Error('userId is required to persist inbox layout preferences');
+      }
+
+      const payload = {};
+      if (typeof partial?.inboxListPosition === 'string') {
+        payload.inboxListPosition = partial.inboxListPosition === 'right' ? 'right' : 'left';
+      }
+      if (partial?.inboxListWidth !== undefined) {
+        const nextWidth = clampWidth(Number(partial.inboxListWidth));
+        if (nextWidth !== undefined) {
+          payload.inboxListWidth = nextWidth;
+        }
+      }
+
+      if (Object.keys(payload).length === 0) {
+        return queryClient.getQueryData(INBOX_LAYOUT_PREFERENCES_QUERY_KEY) ?? DEFAULT_INBOX_LAYOUT_PREFERENCES;
+      }
+
+      const response = await apiPatch(`/api/users/${userId}/preferences`, payload);
+      return response?.data ?? payload;
+    },
+    onMutate: async (partial) => {
+      await queryClient.cancelQueries({ queryKey: INBOX_LAYOUT_PREFERENCES_QUERY_KEY });
+      const previous = queryClient.getQueryData(INBOX_LAYOUT_PREFERENCES_QUERY_KEY);
+
+      queryClient.setQueryData(INBOX_LAYOUT_PREFERENCES_QUERY_KEY, (current) => ({
+        ...DEFAULT_INBOX_LAYOUT_PREFERENCES,
+        ...(current ?? {}),
+        ...(partial ?? {}),
+        inboxListPosition:
+          partial?.inboxListPosition === 'right'
+            ? 'right'
+            : partial?.inboxListPosition === 'left'
+              ? 'left'
+              : current?.inboxListPosition ?? DEFAULT_INBOX_LAYOUT_PREFERENCES.inboxListPosition,
+        inboxListWidth:
+          clampWidth(Number(partial?.inboxListWidth)) ?? current?.inboxListWidth ?? DEFAULT_INBOX_LAYOUT_PREFERENCES.inboxListWidth,
+      }));
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(INBOX_LAYOUT_PREFERENCES_QUERY_KEY, context.previous);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(INBOX_LAYOUT_PREFERENCES_QUERY_KEY, (current) => ({
+        ...DEFAULT_INBOX_LAYOUT_PREFERENCES,
+        ...(current ?? {}),
+        ...(data ?? {}),
+      }));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: INBOX_LAYOUT_PREFERENCES_QUERY_KEY });
+    },
+  });
+};
+
+export default useUpdateInboxLayoutPreferences;

--- a/apps/web/src/features/chat/components/layout/InboxAppShell.jsx
+++ b/apps/web/src/features/chat/components/layout/InboxAppShell.jsx
@@ -1,20 +1,17 @@
-import { useEffect, useState } from 'react';
-import {
-  SidebarProvider,
-  Sidebar,
-  SidebarHeader,
-  SidebarContent,
-  SidebarFooter,
-  SidebarSeparator,
-  SidebarTrigger,
-  SidebarInset,
-  SidebarRail,
-} from '@/components/ui/sidebar.jsx';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeftRight, MessageSquare, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
 import { ScrollArea } from '@/components/ui/scroll-area.jsx';
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet.jsx';
 import { cn } from '@/lib/utils.js';
-import { PanelRightOpen, PanelRightClose, MessageSquare } from 'lucide-react';
 import ContextDrawer from './ContextDrawer.jsx';
+import SplitLayout from './SplitLayout.jsx';
+import { useMediaQuery } from '@/hooks/use-media-query.js';
+import useInboxLayoutPreferences, {
+  DEFAULT_INBOX_LIST_WIDTH,
+  DEFAULT_INBOX_LAYOUT_PREFERENCES,
+} from '../../api/useInboxLayoutPreferences.js';
+import useUpdateInboxLayoutPreferences from '../../api/useUpdateInboxLayoutPreferences.js';
 
 const CONTEXT_PREFERENCE_KEY = 'inbox_context_open';
 
@@ -51,68 +48,237 @@ const InboxAppShell = ({
   context,
   defaultContextOpen = false,
   title = 'Inbox de Leads',
+  currentUser,
 }) => {
   const [contextOpen, setContextOpen] = useState(() => readPreference(CONTEXT_PREFERENCE_KEY, defaultContextOpen));
+  const [desktopListVisible, setDesktopListVisible] = useState(true);
+  const [mobileListOpen, setMobileListOpen] = useState(false);
+  const [localListPosition, setLocalListPosition] = useState(DEFAULT_INBOX_LAYOUT_PREFERENCES.inboxListPosition);
+  const [listWidth, setListWidth] = useState(DEFAULT_INBOX_LIST_WIDTH);
 
   useEffect(() => {
     writePreference(CONTEXT_PREFERENCE_KEY, contextOpen);
   }, [contextOpen]);
 
-  return (
-    <SidebarProvider defaultOpen>
-      <div className="flex min-h-screen bg-slate-950 text-slate-100">
-        <Sidebar collapsible="icon" className="border-slate-900/80 bg-slate-950/90">
-          <SidebarHeader className="px-3 py-4">
-            <div className="flex items-center justify-between gap-3 text-sm font-semibold">
-              <div className="flex items-center gap-2">
-                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 text-sky-300">
-                  <MessageSquare className="h-4 w-4" />
-                </span>
-                <div className="space-y-0.5">
-                  <p className="text-sm font-semibold leading-none">Inbox</p>
-                  <p className="text-xs text-slate-400">Atendimento em tempo real</p>
-                </div>
-              </div>
-              <SidebarTrigger className="hidden text-slate-300 md:inline-flex" />
-            </div>
-          </SidebarHeader>
-          <SidebarSeparator />
-          <SidebarContent className="px-2">
-            <ScrollArea className="h-full pr-2">{sidebar}</ScrollArea>
-          </SidebarContent>
-          <SidebarFooter className="px-2 pb-4 text-xs text-slate-500">
-            <p>⌘B recolhe barra lateral</p>
-          </SidebarFooter>
-        </Sidebar>
-        <SidebarRail />
-        <SidebarInset className="flex flex-1 flex-col">
-          <header className="flex items-center justify-between border-b border-slate-900/60 px-4 py-3">
-            <div className="flex items-center gap-3">
-              <SidebarTrigger className="text-slate-300 md:hidden" />
-              <h1 className="text-base font-semibold text-slate-100 sm:text-lg">{title}</h1>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900"
-              onClick={() => setContextOpen((previous) => !previous)}
-            >
-              {contextOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
-              <span className="ml-2 hidden text-xs font-medium sm:inline">
-                {contextOpen ? 'Ocultar painel' : 'Exibir painel'}
-              </span>
-            </Button>
-          </header>
+  const isNarrowViewport = useMediaQuery('(max-width: 1024px)');
+  const isDesktop = !isNarrowViewport;
 
-          <div className="flex min-h-0 flex-1 overflow-hidden">
-            <div className={cn('flex-1 overflow-hidden', contextOpen ? 'lg:pr-0' : '')}>{children}</div>
-            <ContextDrawer open={contextOpen} onOpenChange={setContextOpen}>
-              {context}
-            </ContextDrawer>
+  useEffect(() => {
+    if (isDesktop) {
+      setMobileListOpen(false);
+    }
+  }, [isDesktop]);
+
+  const preferencesQuery = useInboxLayoutPreferences();
+  const preferences = preferencesQuery.data ?? DEFAULT_INBOX_LAYOUT_PREFERENCES;
+
+  useEffect(() => {
+    if (typeof preferences?.inboxListWidth === 'number' && Number.isFinite(preferences.inboxListWidth)) {
+      setListWidth(preferences.inboxListWidth);
+    }
+  }, [preferences?.inboxListWidth]);
+
+  useEffect(() => {
+    if (preferences?.inboxListPosition) {
+      setLocalListPosition(preferences.inboxListPosition);
+    }
+  }, [preferences?.inboxListPosition]);
+
+  const canPersistPreferences = Boolean(currentUser?.id);
+
+  const effectiveListPosition = useMemo(
+    () => (canPersistPreferences ? preferences?.inboxListPosition ?? 'left' : localListPosition),
+    [canPersistPreferences, preferences?.inboxListPosition, localListPosition]
+  );
+
+  const updatePreferences = useUpdateInboxLayoutPreferences({ userId: currentUser?.id });
+
+  const handleToggleListPosition = useCallback(() => {
+    const nextPosition = effectiveListPosition === 'left' ? 'right' : 'left';
+    setLocalListPosition(nextPosition);
+    if (canPersistPreferences) {
+      updatePreferences.mutate({ inboxListPosition: nextPosition });
+    }
+  }, [effectiveListPosition, canPersistPreferences, updatePreferences]);
+
+  const toggleListVisibility = useCallback(() => {
+    if (isDesktop) {
+      setDesktopListVisible((previous) => !previous);
+    } else {
+      setMobileListOpen((previous) => !previous);
+    }
+  }, [isDesktop]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if ((event.key === 'l' || event.key === 'L') && event.altKey && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault();
+        toggleListVisibility();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [toggleListVisibility]);
+
+  const handleListWidthChange = useCallback((nextWidth) => {
+    setListWidth(nextWidth);
+  }, []);
+
+  const handleListWidthCommit = useCallback(
+    (nextWidth) => {
+      if (canPersistPreferences) {
+        updatePreferences.mutate({ inboxListWidth: nextWidth });
+      }
+    },
+    [canPersistPreferences, updatePreferences]
+  );
+
+  const listBorderClass = effectiveListPosition === 'left' ? 'border-r border-slate-900/70' : 'border-l border-slate-900/70';
+
+  const renderListPane = useCallback(
+    ({ showCloseButton = false } = {}) => (
+      <div className="flex h-full flex-col">
+        <div className="px-4 py-4">
+          <div className="flex items-center justify-between gap-3 text-sm font-semibold text-slate-200">
+            <div className="flex items-center gap-2">
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 text-sky-300">
+                <MessageSquare className="h-4 w-4" />
+              </span>
+              <div className="space-y-0.5">
+                <p className="text-sm font-semibold leading-none">Inbox</p>
+                <p className="text-xs text-slate-400">Atendimento em tempo real</p>
+              </div>
+            </div>
+            {showCloseButton ? (
+              <SheetClose asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-full text-slate-300 hover:text-slate-100"
+                  aria-label="Fechar lista de tickets"
+                >
+                  <PanelLeftClose className="h-4 w-4" />
+                </Button>
+              </SheetClose>
+            ) : null}
           </div>
-        </SidebarInset>
+        </div>
+        <div className="flex-1 overflow-hidden">
+          <ScrollArea className="h-full pr-2">{sidebar}</ScrollArea>
+        </div>
+        <div className="border-t border-slate-900/70 px-4 py-3 text-xs text-slate-500">
+          <p className="font-medium text-slate-400">⌥ L alterna lista</p>
+          <p className="mt-1 text-[11px] uppercase tracking-wide text-slate-600">
+            {canPersistPreferences ? 'Preferência salva automaticamente' : 'Preferência local temporária'}
+          </p>
+        </div>
       </div>
-    </SidebarProvider>
+    ),
+    [sidebar, canPersistPreferences]
+  );
+
+  const headerListButtonLabel = desktopListVisible ? 'Ocultar lista' : 'Mostrar lista';
+  const positionButtonLabel = effectiveListPosition === 'left' ? 'Mover lista para a direita' : 'Mover lista para a esquerda';
+
+  const detailSurface = (
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-slate-950">
+      <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden', contextOpen ? 'lg:pr-0' : '')}>{children}</div>
+      <ContextDrawer open={contextOpen} onOpenChange={setContextOpen}>
+        {context}
+      </ContextDrawer>
+    </div>
+  );
+
+  const listContent = renderListPane();
+  const mobileListContent = renderListPane({ showCloseButton: true });
+
+  const toggleDisabled = preferencesQuery.isFetching || updatePreferences.isPending;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-900/60 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 rounded-full text-slate-300 hover:text-slate-100 lg:hidden"
+            onClick={() => setMobileListOpen(true)}
+            aria-label="Abrir lista de tickets"
+          >
+            <PanelLeftOpen className="h-5 w-5" />
+          </Button>
+          <h1 className="text-base font-semibold text-slate-100 sm:text-lg">{title}</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="hidden border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900 lg:inline-flex"
+            onClick={toggleListVisibility}
+          >
+            {desktopListVisible ? <PanelLeftClose className="h-4 w-4" /> : <PanelLeftOpen className="h-4 w-4" />}
+            <span className="ml-2 hidden text-xs font-medium xl:inline">{headerListButtonLabel}</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900"
+            onClick={handleToggleListPosition}
+            disabled={toggleDisabled && canPersistPreferences}
+          >
+            <ArrowLeftRight className="h-4 w-4" />
+            <span className="ml-2 hidden text-xs font-medium sm:inline">{positionButtonLabel}</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900"
+            onClick={() => setContextOpen((previous) => !previous)}
+          >
+            {contextOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+            <span className="ml-2 hidden text-xs font-medium sm:inline">
+              {contextOpen ? 'Ocultar painel' : 'Exibir painel'}
+            </span>
+          </Button>
+        </div>
+      </header>
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {isDesktop ? (
+          <SplitLayout
+            className="min-h-0 flex-1"
+            list={listContent}
+            detail={detailSurface}
+            listPosition={effectiveListPosition}
+            listClassName={cn('bg-slate-950/90', listBorderClass)}
+            detailClassName="bg-slate-950"
+            listWidth={listWidth}
+            isListVisible={desktopListVisible && Boolean(sidebar)}
+            onListWidthChange={handleListWidthChange}
+            onListWidthCommit={handleListWidthCommit}
+            resizable={desktopListVisible && Boolean(sidebar)}
+          />
+        ) : (
+          detailSurface
+        )}
+      </div>
+      <Sheet open={mobileListOpen} onOpenChange={setMobileListOpen}>
+        <SheetContent
+          side={effectiveListPosition === 'right' ? 'right' : 'left'}
+          className={cn(
+            'w-[min(420px,90vw)] border-slate-900/70 bg-slate-950/95 p-0 text-slate-100',
+            effectiveListPosition === 'left' ? 'border-r' : 'border-l'
+          )}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Lista de tickets</SheetTitle>
+          </SheetHeader>
+          {mobileListContent}
+        </SheetContent>
+      </Sheet>
+    </div>
   );
 };
 

--- a/apps/web/src/features/chat/components/layout/SplitLayout.jsx
+++ b/apps/web/src/features/chat/components/layout/SplitLayout.jsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/utils.js';
+
+const clampWidth = (value, min, max) => {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(Math.max(Math.round(value), min), max);
+};
+
+const SplitLayout = ({
+  list,
+  detail,
+  listPosition = 'left',
+  className,
+  listClassName,
+  detailClassName,
+  minListWidth = 320,
+  maxListWidthPx = 560,
+  maxListWidthToken = '34vw',
+  listWidth,
+  isListVisible = true,
+  onListWidthChange,
+  onListWidthCommit,
+  resizable = true,
+  ...props
+}) => {
+  const numericWidth = useMemo(() => clampWidth(Number(listWidth), minListWidth, maxListWidthPx), [
+    listWidth,
+    minListWidth,
+    maxListWidthPx,
+  ]);
+
+  const fallbackWidth = useMemo(
+    () => `min(${maxListWidthToken}, ${maxListWidthPx}px)`,
+    [maxListWidthToken, maxListWidthPx]
+  );
+
+  const listColumnWidth = numericWidth ? `${numericWidth}px` : fallbackWidth;
+
+  const gridTemplateColumns = isListVisible
+    ? listPosition === 'left'
+      ? `minmax(${minListWidth}px, ${listColumnWidth}) 1fr`
+      : `1fr minmax(${minListWidth}px, ${listColumnWidth})`
+    : '1fr';
+
+  const gridTemplateAreas = isListVisible
+    ? listPosition === 'left'
+      ? '"list detail"'
+      : '"detail list"'
+    : '"detail"';
+
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCleanupRef = useRef(null);
+  const lastWidthRef = useRef(numericWidth ?? minListWidth);
+
+  useEffect(() => {
+    lastWidthRef.current = numericWidth ?? minListWidth;
+  }, [numericWidth, minListWidth]);
+
+  useEffect(() => {
+    return () => {
+      if (typeof dragCleanupRef.current === 'function') {
+        dragCleanupRef.current();
+      }
+    };
+  }, []);
+
+  const teardownDragListeners = () => {
+    if (typeof dragCleanupRef.current === 'function') {
+      dragCleanupRef.current();
+    }
+  };
+
+  const beginDrag = (event) => {
+    if (!isListVisible || !onListWidthChange || typeof event?.clientX !== 'number') {
+      return;
+    }
+
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startingWidth = lastWidthRef.current ?? numericWidth ?? minListWidth;
+
+    const handleMove = (moveEvent) => {
+      if (typeof moveEvent?.clientX !== 'number') {
+        return;
+      }
+
+      const delta = listPosition === 'left' ? moveEvent.clientX - startX : startX - moveEvent.clientX;
+      const nextWidth = clampWidth(startingWidth + delta, minListWidth, maxListWidthPx);
+
+      if (typeof nextWidth === 'number' && nextWidth !== lastWidthRef.current) {
+        lastWidthRef.current = nextWidth;
+        onListWidthChange(nextWidth);
+      }
+    };
+
+    const finish = () => {
+      setIsDragging(false);
+      document.body.style.cursor = '';
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
+      dragCleanupRef.current = null;
+      const latestWidth = lastWidthRef.current;
+      if (typeof latestWidth === 'number') {
+        onListWidthCommit?.(latestWidth);
+      }
+    };
+
+    teardownDragListeners();
+
+    document.body.style.cursor = 'col-resize';
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
+
+    dragCleanupRef.current = finish;
+    setIsDragging(true);
+  };
+
+  const handleResizerPointerDown = (event) => {
+    beginDrag(event);
+  };
+
+  const handleResizerKeyDown = (event) => {
+    if (!isListVisible || !onListWidthChange) {
+      return;
+    }
+
+    const currentWidth = lastWidthRef.current ?? numericWidth ?? minListWidth;
+    const step = event.shiftKey ? 32 : 16;
+    let nextWidth = currentWidth;
+
+    if (event.key === 'ArrowLeft') {
+      nextWidth = clampWidth(currentWidth + (listPosition === 'left' ? -step : step), minListWidth, maxListWidthPx);
+    } else if (event.key === 'ArrowRight') {
+      nextWidth = clampWidth(currentWidth + (listPosition === 'left' ? step : -step), minListWidth, maxListWidthPx);
+    } else if (event.key === 'Home') {
+      nextWidth = minListWidth;
+    } else if (event.key === 'End') {
+      nextWidth = maxListWidthPx;
+    } else {
+      return;
+    }
+
+    if (typeof nextWidth === 'number' && nextWidth !== currentWidth) {
+      event.preventDefault();
+      lastWidthRef.current = nextWidth;
+      onListWidthChange(nextWidth);
+      onListWidthCommit?.(nextWidth);
+    }
+  };
+
+  return (
+    <div
+      className={cn('relative grid h-full min-h-0 w-full gap-0', className)}
+      style={{ gridTemplateColumns, gridTemplateAreas }}
+      data-list-position={listPosition}
+      {...props}
+    >
+      {isListVisible ? (
+        <aside
+          aria-label="Lista de tickets"
+          className={cn('relative min-h-0 min-w-0 overflow-hidden', listClassName)}
+          style={{ gridArea: 'list' }}
+        >
+          {list}
+        </aside>
+      ) : null}
+      <section className={cn('relative min-h-0 min-w-0 overflow-hidden', detailClassName)} style={{ gridArea: 'detail' }}>
+        {detail}
+      </section>
+      {isListVisible && resizable && onListWidthChange ? (
+        <div
+          role="separator"
+          aria-label="Ajustar largura da lista"
+          aria-orientation="vertical"
+          aria-valuemin={minListWidth}
+          aria-valuemax={maxListWidthPx}
+          aria-valuenow={numericWidth ?? minListWidth}
+          tabIndex={0}
+          onPointerDown={handleResizerPointerDown}
+          onKeyDown={handleResizerKeyDown}
+          className={cn(
+            'absolute inset-y-0 z-20 w-2 cursor-col-resize touch-none outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-sky-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
+            listPosition === 'left' ? '-right-1 translate-x-1/2' : '-left-1 -translate-x-1/2',
+            isDragging ? 'bg-slate-600/40' : 'bg-transparent'
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className="absolute inset-y-[30%] left-1/2 w-[3px] -translate-x-1/2 rounded-full bg-slate-700/70"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SplitLayout;

--- a/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
+++ b/apps/web/src/features/whatsapp/WhatsAppConnect.jsx
@@ -2702,9 +2702,6 @@ const WhatsAppConnect = ({
     ? looksLikeWhatsAppJid(instancePendingDelete.id)
     : false;
   const removalDialogTitle = removalTargetIsJid ? 'Desconectar sessão' : 'Remover instância';
-  const removalDialogDescription = removalTargetIsJid
-    ? `Esta ação desconecta a sessão ${removalTargetLabel}. Utilize quando precisar encerrar um dispositivo sincronizado com o broker.`
-    : `Esta ação remove permanentemente a instância ${removalTargetLabel}. Verifique se não há campanhas ativas utilizando este número.`;
   const removalDialogAction = removalTargetIsJid ? 'Desconectar sessão' : 'Remover instância';
 
   return (

--- a/apps/web/src/hooks/use-media-query.js
+++ b/apps/web/src/hooks/use-media-query.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+export const useMediaQuery = (query) => {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined' || typeof query !== 'string') {
+      return false;
+    }
+
+    try {
+      return window.matchMedia(query).matches;
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof query !== 'string') {
+      return undefined;
+    }
+
+    let mediaQueryList;
+    try {
+      mediaQueryList = window.matchMedia(query);
+    } catch {
+      setMatches(false);
+      return undefined;
+    }
+
+    const updateMatch = (event) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQueryList.matches);
+
+    mediaQueryList.addEventListener('change', updateMatch);
+    return () => {
+      mediaQueryList.removeEventListener('change', updateMatch);
+    };
+  }, [query]);
+
+  return matches;
+};
+
+export default useMediaQuery;


### PR DESCRIPTION
## Summary
- replace the inbox shell with a responsive split layout that supports list docking, resizing, mobile drawer access and keyboard toggles
- persist inbox layout preferences via new React Query hooks backed by `/api/preferences` endpoints and an in-memory store
- wire the chat command center to pass the signed-in user, and clean up an unused WhatsApp connect variable

## Testing
- pnpm --filter web lint
- pnpm --filter @ticketz/api typecheck *(fails: existing type errors in whatsapp and shared packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e534bbb71c833286423f07abd24b34