### PR TITLE
Refine inbox toolbar layout and quick reply menu

### DIFF
--- a/apps/web/src/features/chat/components/ConversationArea/Composer.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/Composer.jsx
@@ -3,7 +3,7 @@ import { Textarea } from '@/components/ui/textarea.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { Brain, Paperclip, Smile, Send, FileText, Loader2, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge.jsx';
-import QuickReplyList from '../Shared/QuickReplyList.jsx';
+import QuickReplyMenu from '../Shared/QuickReplyMenu.jsx';
 import TemplatePicker from './TemplatePicker.jsx';
 
 const DEFAULT_REPLIES = [
@@ -47,6 +47,7 @@ export const Composer = ({
   const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
   const [attachments, setAttachments] = useState([]);
   const fileInputRef = useRef(null);
+  const [quickReplies, setQuickReplies] = useState(() => [...DEFAULT_REPLIES]);
 
   const placeholder = useMemo(() => {
     if (disabled) {
@@ -131,14 +132,6 @@ export const Composer = ({
 
   return (
     <div className="rounded-xl border border-slate-800/60 bg-slate-950/85 p-3">
-      <QuickReplyList
-        replies={DEFAULT_REPLIES}
-        onSelect={(text) => {
-          setValue((current) => `${current ? `${current}\n` : ''}${text}`);
-        }}
-        className="mb-2 flex flex-wrap gap-2"
-      />
-
       {attachments.length > 0 ? (
         <div className="mb-3 flex flex-wrap gap-2">
           {attachments.map((file) => (
@@ -186,6 +179,21 @@ export const Composer = ({
           className="min-h-[88px] flex-1 resize-none border-slate-800 bg-slate-900/70 text-slate-100 placeholder:text-slate-600"
         />
         <div className="flex flex-col gap-2">
+          <QuickReplyMenu
+            replies={quickReplies}
+            onSelect={(text) => {
+              setValue((current) => `${current ? `${current}\n` : ''}${text}`);
+            }}
+            onCreate={(reply) => {
+              setQuickReplies((current) => {
+                const exists = current.some((item) => item.label === reply.label && item.text === reply.text);
+                if (exists) {
+                  return current;
+                }
+                return [...current, reply];
+              });
+            }}
+          />
           <Button
             variant="ghost"
             size="icon"

--- a/apps/web/src/features/chat/components/FilterToolbar/FilterToolbar.jsx
+++ b/apps/web/src/features/chat/components/FilterToolbar/FilterToolbar.jsx
@@ -9,15 +9,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select.jsx';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.jsx';
 import { cn } from '@/lib/utils.js';
-import { Filter, RefreshCw } from 'lucide-react';
+import { Filter, RefreshCw, Search } from 'lucide-react';
 
-const CONTEXT_TABS = [
-  { id: 'overview', label: 'Visão Geral' },
-  { id: 'agreements', label: 'Convênios' },
-  { id: 'whatsapp', label: 'WhatsApp' },
-  { id: 'inbox', label: 'Inbox' },
-];
+const DEFAULT_FILTERS = {
+  scope: 'team',
+  state: 'open',
+  window: 'in_window',
+  outcome: 'all',
+};
 
 const SCOPE_OPTIONS = [
   { value: 'team', label: 'Equipe' },
@@ -71,16 +72,25 @@ const FilterToolbar = ({
   loading,
   onRefresh,
 }) => {
-  const [contextTab, setContextTab] = useState('inbox');
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const effectiveFilters = useMemo(
     () => ({
-      scope: filters?.scope ?? 'team',
-      state: filters?.state ?? 'open',
-      window: filters?.window ?? 'in_window',
-      outcome: filters?.outcome ?? 'all',
+      scope: filters?.scope ?? DEFAULT_FILTERS.scope,
+      state: filters?.state ?? DEFAULT_FILTERS.state,
+      window: filters?.window ?? DEFAULT_FILTERS.window,
+      outcome: filters?.outcome ?? DEFAULT_FILTERS.outcome,
     }),
     [filters]
+  );
+
+  const activeFiltersCount = useMemo(
+    () =>
+      Object.entries(effectiveFilters).reduce(
+        (count, [key, value]) => (DEFAULT_FILTERS[key] !== value ? count + 1 : count),
+        0
+      ),
+    [effectiveFilters]
   );
 
   const applyFilters = (updater) => {
@@ -91,128 +101,201 @@ const FilterToolbar = ({
     });
   };
 
-  return (
-    <div className="space-y-4 rounded-xl border border-slate-900/70 bg-slate-950/80 p-4 shadow-sm">
-      <div className="flex flex-wrap items-center gap-2">
-        {CONTEXT_TABS.map((tab) => {
-          const active = tab.id === contextTab;
-          return (
-            <Button
-              key={tab.id}
-              variant={active ? 'default' : 'ghost'}
-              size="sm"
-              className={cn(
-                'rounded-full border border-slate-900/70 px-4 text-xs font-medium uppercase tracking-wide',
-                active ? 'bg-sky-600 text-white hover:bg-sky-600/90' : 'text-slate-300 hover:bg-slate-900'
-              )}
-              onClick={() => setContextTab(tab.id)}
-            >
-              {tab.label}
-            </Button>
-          );
-        })}
+  const getOptionLabel = (options, value) => options.find((option) => option.value === value)?.label ?? value;
 
-        <div className="ml-auto flex items-center gap-2">
-          <Input
-            value={search}
-            onChange={(event) => onSearchChange?.(event.target.value)}
-            placeholder="Buscar tickets, contatos..."
-            className="h-9 w-64 bg-slate-900/70 text-slate-100 placeholder:text-slate-500"
-          />
+  const filterSummaries = useMemo(
+    () => [
+      { id: 'scope', label: 'Responsável', value: getOptionLabel(SCOPE_OPTIONS, effectiveFilters.scope) },
+      { id: 'state', label: 'Status', value: getOptionLabel(STATE_OPTIONS, effectiveFilters.state) },
+      { id: 'window', label: 'Janela', value: getOptionLabel(WINDOW_OPTIONS, effectiveFilters.window) },
+      { id: 'outcome', label: 'Resultado', value: getOptionLabel(OUTCOME_OPTIONS, effectiveFilters.outcome) },
+    ],
+    [effectiveFilters]
+  );
+
+  const handleResetFilters = () => {
+    applyFilters(DEFAULT_FILTERS);
+    setFiltersOpen(false);
+  };
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-900/70 bg-slate-950/80 p-5 shadow-[0_20px_60px_rgba(15,23,42,0.35)]">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-xl space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-slate-500">Painel de atendimento</p>
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold text-slate-100">Inbox de Leads</h2>
+            <p className="text-sm text-slate-400">
+              Priorize as conversas certas e acompanhe os tickets sem deixar o foco se perder.
+            </p>
+          </div>
+        </div>
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+          <div className="relative sm:w-64">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <Input
+              value={search}
+              onChange={(event) => onSearchChange?.(event.target.value)}
+              placeholder="Buscar tickets, contatos..."
+              className="h-10 w-full rounded-xl border-slate-800/60 bg-slate-900/60 pl-9 text-slate-100 placeholder:text-slate-500"
+            />
+          </div>
           <Button
             variant="outline"
             size="sm"
-            className="border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900"
+            className="h-10 rounded-xl border-slate-800 bg-slate-900/60 text-slate-200 hover:bg-slate-900"
             onClick={onRefresh}
             disabled={loading}
           >
             <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
-            <span className="ml-2 text-xs font-medium">Sincronizar</span>
+            <span className="ml-2 text-xs font-semibold uppercase tracking-wide">Sincronizar</span>
           </Button>
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
-        <div className="flex items-center gap-2">
-          <Filter className="h-4 w-4 text-slate-500" />
-          <span className="font-semibold text-slate-200">Quadro atual</span>
-        </div>
+      <div className="h-px w-full bg-slate-900/60" />
 
-        <Select
-          value={effectiveFilters.scope}
-          onValueChange={(value) => applyFilters({ scope: value })}
-        >
-          <SelectTrigger size="sm" className="min-w-[120px] bg-slate-900/70 text-slate-100">
-            <SelectValue placeholder="Equipe" />
-          </SelectTrigger>
-          <SelectContent>
-            {SCOPE_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={effectiveFilters.state}
-          onValueChange={(value) => applyFilters({ state: value })}
-        >
-          <SelectTrigger size="sm" className="min-w-[140px] bg-slate-900/70 text-slate-100">
-            <SelectValue placeholder="Status" />
-          </SelectTrigger>
-          <SelectContent>
-            {STATE_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={effectiveFilters.window}
-          onValueChange={(value) => applyFilters({ window: value })}
-        >
-          <SelectTrigger size="sm" className="min-w-[150px] bg-slate-900/70 text-slate-100">
-            <SelectValue placeholder="Janela" />
-          </SelectTrigger>
-          <SelectContent>
-            {WINDOW_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={effectiveFilters.outcome}
-          onValueChange={(value) => applyFilters({ outcome: value })}
-        >
-          <SelectTrigger size="sm" className="min-w-[140px] bg-slate-900/70 text-slate-100">
-            <SelectValue placeholder="Resultado" />
-          </SelectTrigger>
-          <SelectContent>
-            {OUTCOME_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <div className="ml-auto flex flex-wrap items-center gap-2">
-          {SAVED_PRESETS.map((preset) => (
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          {filterSummaries.map((summary) => (
             <Badge
-              key={preset.id}
+              key={summary.id}
               variant="outline"
-              className="cursor-pointer border-slate-800/80 bg-slate-900/60 px-3 py-1 text-[11px] font-medium text-slate-200 hover:bg-slate-900"
-              onClick={() => applyFilters(preset.filters)}
+              className="rounded-full border-slate-800/70 bg-slate-950/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-slate-300"
             >
-              {preset.label}
+              <span className="text-slate-500">{summary.label}</span>
+              <span className="ml-2 text-slate-100">{summary.value}</span>
             </Badge>
           ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-full border-slate-800/80 bg-slate-950/60 px-4 text-slate-200 hover:bg-slate-900"
+              >
+                <Filter className="h-4 w-4" />
+                <span className="ml-2 text-xs font-semibold uppercase tracking-wide">Ajustar filtros</span>
+                {activeFiltersCount > 0 ? (
+                  <Badge
+                    variant="secondary"
+                    className="ml-2 rounded-full border-0 bg-sky-500/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-200"
+                  >
+                    {activeFiltersCount}
+                  </Badge>
+                ) : null}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-[320px] rounded-xl border-slate-800/80 bg-slate-950/95 p-4 text-slate-100 shadow-xl"
+            >
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Responsável</p>
+                  <Select
+                    value={effectiveFilters.scope}
+                    onValueChange={(value) => applyFilters({ scope: value })}
+                  >
+                    <SelectTrigger className="h-10 rounded-lg border-slate-800/60 bg-slate-900/60 text-slate-100">
+                      <SelectValue placeholder="Equipe" />
+                    </SelectTrigger>
+                    <SelectContent className="border-slate-800/80 bg-slate-950 text-slate-100">
+                      {SCOPE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Status</p>
+                  <Select
+                    value={effectiveFilters.state}
+                    onValueChange={(value) => applyFilters({ state: value })}
+                  >
+                    <SelectTrigger className="h-10 rounded-lg border-slate-800/60 bg-slate-900/60 text-slate-100">
+                      <SelectValue placeholder="Status" />
+                    </SelectTrigger>
+                    <SelectContent className="border-slate-800/80 bg-slate-950 text-slate-100">
+                      {STATE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Janela</p>
+                  <Select
+                    value={effectiveFilters.window}
+                    onValueChange={(value) => applyFilters({ window: value })}
+                  >
+                    <SelectTrigger className="h-10 rounded-lg border-slate-800/60 bg-slate-900/60 text-slate-100">
+                      <SelectValue placeholder="Janela" />
+                    </SelectTrigger>
+                    <SelectContent className="border-slate-800/80 bg-slate-950 text-slate-100">
+                      {WINDOW_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Resultado</p>
+                  <Select
+                    value={effectiveFilters.outcome}
+                    onValueChange={(value) => applyFilters({ outcome: value })}
+                  >
+                    <SelectTrigger className="h-10 rounded-lg border-slate-800/60 bg-slate-900/60 text-slate-100">
+                      <SelectValue placeholder="Resultado" />
+                    </SelectTrigger>
+                    <SelectContent className="border-slate-800/80 bg-slate-950 text-slate-100">
+                      {OUTCOME_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-center rounded-lg border border-slate-800/60 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-300 hover:bg-slate-900"
+                  onClick={handleResetFilters}
+                >
+                  Limpar filtros
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {SAVED_PRESETS.map((preset) => (
+              <Button
+                key={preset.id}
+                variant="secondary"
+                size="sm"
+                title={preset.description}
+                className="h-9 rounded-full border-0 bg-slate-900/70 px-3 text-[11px] font-medium uppercase tracking-wide text-slate-300 hover:bg-slate-900"
+                onClick={() => applyFilters(preset.filters)}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/chat/components/Shared/QuickReplyMenu.jsx
+++ b/apps/web/src/features/chat/components/Shared/QuickReplyMenu.jsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button.jsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.jsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Label } from '@/components/ui/label.jsx';
+import { Textarea } from '@/components/ui/textarea.jsx';
+import { cn } from '@/lib/utils.js';
+import { MessageSquarePlus, Plus } from 'lucide-react';
+
+const sanitizeReply = (reply) => {
+  if (!reply) return null;
+  const label = reply.label?.trim();
+  const text = reply.text?.trim();
+  if (!label || !text) return null;
+  return {
+    id: reply.id ?? `quick-reply-${label.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`,
+    label,
+    text,
+  };
+};
+
+const QuickReplyMenu = ({ replies = [], onSelect, onCreate, className }) => {
+  const [open, setOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [form, setForm] = useState({ label: '', text: '' });
+
+  const availableReplies = useMemo(
+    () => replies.map((reply) => sanitizeReply(reply)).filter(Boolean),
+    [replies]
+  );
+
+  const isSubmitDisabled = !form.label.trim() || !form.text.trim();
+
+  const handleSelect = (reply) => {
+    if (typeof onSelect === 'function') {
+      onSelect(reply.text, reply);
+    }
+    setOpen(false);
+  };
+
+  const handleCreate = (event) => {
+    event.preventDefault();
+    const payload = sanitizeReply(form);
+    if (!payload) {
+      return;
+    }
+    if (typeof onCreate === 'function') {
+      onCreate(payload);
+    }
+    setForm({ label: '', text: '' });
+    setDialogOpen(false);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <DropdownMenu open={open} onOpenChange={(value) => setOpen(value)}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              'h-9 w-9 rounded-full border border-slate-800/60 bg-slate-950/60 text-slate-300 hover:bg-slate-900 hover:text-white',
+              className
+            )}
+          >
+            <MessageSquarePlus className="h-4 w-4" />
+            <span className="sr-only">Abrir respostas rápidas</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-64 rounded-xl border-slate-800/80 bg-slate-950/95 p-2 text-slate-100 shadow-xl"
+        >
+          <DropdownMenuLabel className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Respostas rápidas
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator className="my-1 bg-slate-900/60" />
+          {availableReplies.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-slate-500">Nenhuma resposta cadastrada ainda.</div>
+          ) : (
+            availableReplies.map((reply) => (
+              <DropdownMenuItem
+                key={reply.id}
+                className="flex flex-col items-start gap-1 rounded-lg px-3 py-2 text-left text-xs text-slate-300 focus:bg-slate-900 focus:text-slate-100"
+                onSelect={(event) => {
+                  event.preventDefault();
+                  handleSelect(reply);
+                }}
+              >
+                <span className="text-sm font-medium text-slate-100">{reply.label}</span>
+                <span className="line-clamp-2 text-xs text-slate-500">{reply.text}</span>
+              </DropdownMenuItem>
+            ))
+          )}
+          <DropdownMenuSeparator className="my-1 bg-slate-900/60" />
+          <DropdownMenuItem
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium uppercase tracking-wide text-sky-300 focus:bg-slate-900 focus:text-sky-200"
+            onSelect={(event) => {
+              event.preventDefault();
+              setDialogOpen(true);
+            }}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Nova resposta rápida
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(value) => {
+          setDialogOpen(value);
+          if (!value) {
+            setForm({ label: '', text: '' });
+          }
+        }}
+      >
+        <DialogContent className="max-w-md rounded-2xl border-slate-800/80 bg-slate-950/95 text-slate-100">
+          <DialogHeader>
+            <DialogTitle>Nova resposta rápida</DialogTitle>
+            <DialogDescription>
+              Crie atalhos para mensagens que você usa com frequência e ganhe velocidade no atendimento.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="quick-reply-label" className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Nome visível
+              </Label>
+              <Input
+                id="quick-reply-label"
+                value={form.label}
+                onChange={(event) => setForm((current) => ({ ...current, label: event.target.value }))}
+                placeholder="Ex.: Saudação inicial"
+                className="h-10 rounded-lg border-slate-800/60 bg-slate-900/60 text-sm text-slate-100 placeholder:text-slate-500"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="quick-reply-text" className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Mensagem
+              </Label>
+              <Textarea
+                id="quick-reply-text"
+                value={form.text}
+                onChange={(event) => setForm((current) => ({ ...current, text: event.target.value }))}
+                placeholder="Escreva a mensagem completa que será inserida na conversa"
+                className="min-h-[120px] rounded-lg border-slate-800/60 bg-slate-900/60 text-sm text-slate-100 placeholder:text-slate-500"
+              />
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                className="border border-slate-800/60 bg-transparent text-slate-300 hover:bg-slate-900"
+                onClick={() => setDialogOpen(false)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                disabled={isSubmitDisabled}
+                className="bg-sky-600 text-white hover:bg-sky-500"
+              >
+                Salvar resposta
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default QuickReplyMenu;


### PR DESCRIPTION
## Summary
- redesign the inbox toolbar with a contextual header, compact filter summary, and a popover for advanced filter selections
- add a reusable quick reply menu that exposes saved replies via an icon and allows creating new shortcuts from the composer

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e54450abe48332913cdce2d8913590