### PR TITLE
Refine inbox navigation context cues

### DIFF
--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -18,7 +18,6 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
-import { Badge } from '@/components/ui/badge.jsx';
 import './Layout.css';
 import HealthIndicator from './HealthIndicator.jsx';
 import TenantSelector from './TenantSelector.jsx';
@@ -50,15 +49,16 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
     return () => window.removeEventListener('leadengine:inbox-count', handler);
   }, []);
 
+  const inboxLabel = typeof inboxCount === 'number' ? `Inbox (${inboxCount})` : 'Inbox';
+
   const navigation = [
     { id: 'dashboard', name: 'Visão Geral', icon: Home },
     { id: 'agreements', name: 'Convênios', icon: Briefcase },
     { id: 'whatsapp', name: 'WhatsApp', icon: QrCode },
     {
       id: 'inbox',
-      name: 'Inbox de Leads',
+      name: inboxLabel,
       icon: MessageSquare,
-      badge: typeof inboxCount === 'number' ? inboxCount : null,
     },
     { id: 'reports', name: 'Relatórios', icon: BarChart3 },
     { id: 'settings', name: 'Configurações', icon: Settings },
@@ -119,11 +119,6 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
                 >
                   <item.icon className="nav-icon" />
                   <span className="nav-text">{item.name}</span>
-                  {item.badge ? (
-                    <Badge variant="secondary" className="nav-badge">
-                      {item.badge}
-                    </Badge>
-                  ) : null}
                 </button>
               </li>
             ))}

--- a/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
@@ -8,22 +8,20 @@ import {
 } from '@/components/ui/breadcrumb.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
 import { cn } from '@/lib/utils.js';
+import { MessageSquare } from 'lucide-react';
 
 export const InboxHeader = ({
   stepLabel,
-  selectedAgreement,
   campaign,
   onboarding,
-  leadCount = 0,
 }) => {
-  const agreementName = selectedAgreement?.name;
   const activeStep = onboarding?.activeStep ?? 0;
   const nextStage = onboarding?.stages?.[activeStep + 1]?.title ?? 'Relatórios';
   const campaignName = campaign?.name;
 
   const breadcrumbItems = [
     { label: 'Leads', href: '#leads' },
-    { label: 'Inbox', current: true },
+    { label: 'Inbox', current: true, icon: MessageSquare },
   ];
 
   return (
@@ -44,8 +42,9 @@ export const InboxHeader = ({
             {breadcrumbItems.map((item, index) => (
               <BreadcrumbItem key={item.label}>
                 {item.current ? (
-                  <BreadcrumbPage className="text-sm font-medium text-foreground/90">
-                    {item.label}
+                  <BreadcrumbPage className="flex items-center gap-1.5 text-sm font-medium text-foreground/90">
+                    {item.icon ? <item.icon className="h-3.5 w-3.5 text-muted-foreground/70" aria-hidden /> : null}
+                    <span>{item.label}</span>
                   </BreadcrumbPage>
                 ) : (
                   <BreadcrumbLink
@@ -61,20 +60,9 @@ export const InboxHeader = ({
           </BreadcrumbList>
         </Breadcrumb>
 
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div className="space-y-2">
-            <h1 className="text-[1.625rem] font-semibold leading-tight tracking-tight text-foreground">
-              Inbox de Leads
-            </h1>
-            <p className="max-w-xl text-sm text-muted-foreground">
-              Leads do convênio {agreementName ?? 'selecionado'} sincronizados automaticamente após cada mensagem no WhatsApp
-              conectado.
-            </p>
-          </div>
-          <div className="text-right text-xs text-muted-foreground/80">
-            <p className="font-medium text-foreground/80">{leadCount} leads ativos</p>
-            <p>Próximo passo: {nextStage}</p>
-          </div>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <h1 className="text-[1.625rem] font-semibold leading-tight tracking-tight text-foreground">Inbox de Leads</h1>
+          <p className="text-xs text-muted-foreground/80">Próximo passo: {nextStage}</p>
         </div>
       </div>
 

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -687,10 +687,8 @@ export const LeadInbox = ({
     <div className="space-y-8">
       <InboxHeader
         stepLabel={stepLabel}
-        selectedAgreement={selectedAgreement}
         campaign={campaign}
         onboarding={onboarding}
-        leadCount={filteredCount}
       />
 
       <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)_360px]">


### PR DESCRIPTION
## Summary
- simplify the inbox header by removing redundant subtitle text and shifting the lead count out of the header
- add a subtle breadcrumb with an inbox icon to reinforce navigation context without repetition
- move the dynamic lead count badge into the sidebar label and update the inbox header usage accordingly

## Testing
- pnpm web:dev *(fails: No projects matched the filters)*

------
https://chatgpt.com/codex/tasks/task_e_68e5597e7c6083328e6cc34b0fbfeb08