### PR TITLE
Refine leads inbox hierarchy

### DIFF
--- a/apps/web/src/features/leads/inbox/components/GlobalFiltersBar.jsx
+++ b/apps/web/src/features/leads/inbox/components/GlobalFiltersBar.jsx
@@ -48,7 +48,10 @@ const SavedViewChip = ({ view, isActive, onSelect, onDelete }) => {
         )}
       >
         <span>{view.name}</span>
-        <Badge variant={isActive ? 'default' : 'outline'} className="px-2 text-[10px]">
+        <Badge
+          variant={isActive ? 'info' : 'outline'}
+          className="border border-white/10 px-2 text-[10px] text-muted-foreground/80"
+        >
           {view.count ?? 0}
         </Badge>
       </button>

--- a/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
@@ -27,30 +27,30 @@ export const InboxHeader = ({
   ];
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.24em] text-muted-foreground/70">
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.26em] text-muted-foreground/70">
         <Badge
           variant="outline"
-          className="border-border/60 bg-transparent px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground"
+          className="border-border/60 bg-transparent px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground"
         >
           {stepLabel}
         </Badge>
-        <span className="text-[11px] font-medium text-muted-foreground/80">Fluxo concluído</span>
+        <span className="text-[11px] font-medium text-muted-foreground/75">Fluxo concluído</span>
       </div>
 
-      <div className="flex flex-col gap-3">
-        <Breadcrumb className="text-xs text-muted-foreground/70">
+      <div className="flex flex-col gap-4">
+        <Breadcrumb className="text-xs text-muted-foreground/65">
           <BreadcrumbList>
             {breadcrumbItems.map((item, index) => (
               <BreadcrumbItem key={item.label}>
                 {item.current ? (
-                  <BreadcrumbPage className="text-sm font-medium text-foreground/90">
+                  <BreadcrumbPage className="text-sm font-medium text-foreground/85">
                     {item.label}
                   </BreadcrumbPage>
                 ) : (
                   <BreadcrumbLink
                     href={item.href}
-                    className="text-xs font-medium text-muted-foreground/80 hover:text-foreground/80"
+                    className="text-xs font-medium text-muted-foreground/75 hover:text-foreground/85"
                   >
                     {item.label}
                   </BreadcrumbLink>
@@ -61,19 +61,20 @@ export const InboxHeader = ({
           </BreadcrumbList>
         </Breadcrumb>
 
-        <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-6">
           <div className="space-y-2">
-            <h1 className="text-[1.625rem] font-semibold leading-tight tracking-tight text-foreground">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
               Inbox de Leads
             </h1>
-            <p className="max-w-xl text-sm text-muted-foreground">
+            <p className="max-w-xl text-sm leading-relaxed text-muted-foreground/90">
               Leads do convênio {agreementName ?? 'selecionado'} sincronizados automaticamente após cada mensagem no WhatsApp
               conectado.
             </p>
           </div>
-          <div className="text-right text-xs text-muted-foreground/80">
-            <p className="font-medium text-foreground/80">{leadCount} leads ativos</p>
-            <p>Próximo passo: {nextStage}</p>
+          <div className="flex flex-col items-end gap-1 rounded-2xl border border-white/5 bg-white/[0.04] px-4 py-3 text-right text-xs text-muted-foreground/80">
+            <p className="text-[11px] font-medium uppercase tracking-[0.26em] text-muted-foreground/70">Status atual</p>
+            <p className="text-base font-semibold text-foreground/90">{leadCount} leads ativos</p>
+            <p className="text-[12px] text-muted-foreground/70">Próximo passo: {nextStage}</p>
           </div>
         </div>
       </div>
@@ -82,7 +83,7 @@ export const InboxHeader = ({
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground/80">
           <span className="font-medium text-foreground/80">Campanha ativa</span>
           <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-            <span className={cn('rounded-full bg-white/5 px-2.5 py-1 text-[11px] font-medium text-foreground/90')}>
+            <span className={cn('rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-medium text-foreground/85')}>
               {campaignName}
             </span>
           </div>

--- a/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
@@ -9,10 +9,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/5 text-muted-foreground',
-  contacted: 'border-sky-500/40 bg-sky-500/10 text-sky-100',
-  won: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
-  lost: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  allocated: 'border-white/10 bg-white/[0.04] text-muted-foreground/85',
+  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
+  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
+  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
 };
 
 const formatCurrency = (value) => {
@@ -53,54 +53,58 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
       onClick={() => onSelect?.(allocation)}
       onDoubleClick={() => (allocation && onDoubleOpen ? onDoubleOpen(allocation) : null)}
       className={cn(
-        'group flex w-full flex-col gap-3 rounded-3xl border border-white/5 bg-white/[0.03] p-4 text-left transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
+        'group flex w-full flex-col gap-4 rounded-3xl border border-white/6 bg-white/[0.02] p-5 text-left transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
         isActive
-          ? 'border-sky-500/50 bg-sky-500/10 shadow-[0_18px_48px_rgba(14,116,144,0.28)] focus-visible:ring-sky-400'
-          : 'hover:border-sky-500/30 hover:bg-white/[0.05] focus-visible:ring-sky-400/40'
+          ? 'border-sky-500/45 bg-sky-500/10 shadow-[0_18px_48px_rgba(14,116,144,0.24)] focus-visible:ring-sky-400'
+          : 'hover:border-sky-500/25 hover:bg-white/[0.05] focus-visible:ring-sky-400/40'
       )}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/70">Lead</p>
-          <h3 className="text-base font-semibold leading-tight text-foreground group-hover:text-foreground/95">
-            {allocation.fullName}
-          </h3>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground/65">Lead</p>
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold leading-snug text-foreground group-hover:text-foreground/95">
+              {allocation.fullName}
+            </h3>
+            <p className="text-sm text-muted-foreground/75">{formatDocument(allocation.document)}</p>
+          </div>
         </div>
         <Badge
           variant="outline"
-          className={cn('border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide', statusTone)}
+          className={cn(
+            'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+            statusTone
+          )}
         >
           {statusLabel}
         </Badge>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 text-sm text-muted-foreground/80 sm:grid-cols-2">
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Documento</p>
-          <p className="font-medium text-foreground/90">{formatDocument(allocation.document)}</p>
-        </div>
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Registros</p>
-          <p className="font-medium text-foreground/90">{resolveRegistrations(allocation.registrations)}</p>
-        </div>
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Score</p>
-          <p className="font-medium text-foreground/90">{allocation.score ?? '—'}</p>
-        </div>
-        <div>
+      <div className="grid gap-3 text-sm text-muted-foreground/80 sm:grid-cols-3">
+        <div className="space-y-1.5">
           <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Telefone</p>
           <p className="font-medium text-foreground/90">{allocation.phone ?? '—'}</p>
         </div>
+        <div className="space-y-1.5">
+          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Score</p>
+          <p className="font-medium text-foreground/90">{allocation.score ?? '—'}</p>
+        </div>
+        <div className="space-y-1.5">
+          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Registros</p>
+          <p className="font-medium text-foreground/90">{resolveRegistrations(allocation.registrations)}</p>
+        </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 text-sm">
-        <div className="space-y-1">
+      <div className="grid gap-3 border-t border-white/5 pt-3 text-sm sm:grid-cols-2">
+        <div className="space-y-1.5">
           <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem bruta</p>
-          <p className="font-semibold text-foreground/90">{formatCurrency(allocation.margin)}</p>
+          <p className="text-base font-semibold text-foreground/90">{formatCurrency(allocation.margin)}</p>
         </div>
-        <div className="space-y-1">
+        <div className="space-y-1.5">
           <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem disponível</p>
-          <p className="font-semibold text-foreground/90">{formatCurrency(allocation.netMargin ?? allocation.margin)}</p>
+          <p className="text-base font-semibold text-foreground/90">
+            {formatCurrency(allocation.netMargin ?? allocation.margin)}
+          </p>
         </div>
       </div>
     </button>

--- a/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
@@ -19,10 +19,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/5 text-muted-foreground',
-  contacted: 'border-sky-500/40 bg-sky-500/10 text-sky-100',
-  won: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
-  lost: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  allocated: 'border-white/10 bg-white/[0.05] text-muted-foreground/85',
+  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
+  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
+  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
 };
 
 const ensureDate = (value) => {
@@ -89,16 +89,19 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
   return (
     <div className="flex h-full min-h-[520px] flex-col rounded-3xl border border-white/5 bg-slate-950/70 shadow-[0_8px_32px_rgba(15,23,42,0.32)]">
       <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/5 px-6 py-4">
-        <div className="space-y-1">
-          <p className="text-[11px] uppercase tracking-[0.28em] text-muted-foreground/70">Timeline</p>
+        <div className="space-y-2">
+          <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-muted-foreground/70">Timeline</p>
           <div className="flex flex-wrap items-center gap-3">
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">
               {allocation ? allocation.fullName : 'Selecione um lead'}
             </h2>
             {allocation ? (
               <Badge
                 variant="outline"
-                className={cn('border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide', statusTone)}
+                className={cn(
+                  'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+                  statusTone
+                )}
               >
                 {statusLabel}
               </Badge>
@@ -110,7 +113,7 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
         </div>
         <Button
           size="sm"
-          className="gap-2 rounded-full bg-emerald-500/90 px-4 py-2 text-sm font-semibold text-emerald-950 shadow-[0_8px_24px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
+          className="gap-2 rounded-full bg-emerald-500/90 px-4 py-2 text-sm font-medium text-emerald-950 shadow-[0_8px_24px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
           onClick={() => (allocation && onOpenWhatsApp ? onOpenWhatsApp(allocation) : null)}
           disabled={!allocation?.phone || !onOpenWhatsApp}
         >

--- a/apps/web/src/features/leads/inbox/components/LeadProfilePanel.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadProfilePanel.jsx
@@ -22,10 +22,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/5 text-muted-foreground',
-  contacted: 'border-sky-500/40 bg-sky-500/10 text-sky-100',
-  won: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
-  lost: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  allocated: 'border-white/10 bg-white/[0.05] text-muted-foreground/85',
+  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
+  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
+  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
 };
 
 const formatCurrency = (value) => {
@@ -98,11 +98,16 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp }) => {
     <Card className="rounded-3xl border-white/5 bg-slate-950/70 shadow-[0_6px_28px_rgba(15,23,42,0.38)]">
       <CardHeader className="space-y-3 pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm font-semibold text-foreground/90">Informações do lead</CardTitle>
+          <CardTitle className="text-sm font-semibold tracking-[0.12em] text-foreground/90 uppercase">
+            Informações do lead
+          </CardTitle>
           {allocation ? (
             <Badge
               variant="outline"
-              className={cn('border px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide', statusTone)}
+              className={cn(
+                'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+                statusTone
+              )}
             >
               {statusLabel}
             </Badge>
@@ -134,7 +139,7 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp }) => {
             size="sm"
             onClick={() => (allocation && onOpenWhatsApp ? onOpenWhatsApp(allocation) : null)}
             disabled={!allocation?.phone || !onOpenWhatsApp}
-            className="group flex items-center justify-center gap-2 rounded-2xl bg-emerald-500/90 px-4 py-3 text-sm font-semibold text-emerald-950 shadow-[0_10px_30px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
+            className="group flex items-center justify-center gap-2 rounded-2xl bg-emerald-500/90 px-4 py-3 text-sm font-medium text-emerald-950 shadow-[0_10px_30px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
           >
             <Phone className="h-4 w-4" /> Abrir conversa
           </Button>


### PR DESCRIPTION
## Summary
- rebalance the inbox header and status summary to clarify context and progress information
- neutralize lead status badges and reflow allocation cards for better spacing and readability
- soften saved-view chips and align action buttons with medium-weight styling across panels

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e5593aa0808332a19e4cbc4c9202ee