### PR TITLE
Redesign inbox layout with three-panel structure

### DIFF
--- a/apps/web/src/features/chat/ChatCommandCenter.jsx
+++ b/apps/web/src/features/chat/ChatCommandCenter.jsx
@@ -201,27 +201,23 @@ export const ChatCommandCenter = ({ tenantId: tenantIdProp, currentUser }) => {
         />
       }
     >
-      <div className="flex h-full flex-1 justify-center bg-gradient-to-br from-slate-950/60 via-slate-950 to-slate-950/80">
-        <div className="flex h-full w-full max-w-6xl flex-col gap-4 px-4 pb-6 pt-4">
-          <ConversationArea
-            ticket={controller.selectedTicket}
-            conversation={controller.conversation}
-            messagesQuery={controller.messagesQuery}
-            onSendMessage={sendMessage}
-            onCreateNote={createNote}
-          onMarkWon={markWon}
-          onMarkLost={markLost}
-          onAssign={() => assignToMe(controller.selectedTicket)}
-          onGenerateProposal={() =>
-            toast.info('Gerador de proposta', { description: 'Integração com mini simulador em breve.' })
-          }
-          typingIndicator={controller.typingIndicator}
-          quality={quality}
-          isSending={controller.sendMessageMutation.isPending}
-          sendError={controller.sendMessageMutation.error}
-        />
-        </div>
-      </div>
+      <ConversationArea
+        ticket={controller.selectedTicket}
+        conversation={controller.conversation}
+        messagesQuery={controller.messagesQuery}
+        onSendMessage={sendMessage}
+        onCreateNote={createNote}
+        onMarkWon={markWon}
+        onMarkLost={markLost}
+        onAssign={() => assignToMe(controller.selectedTicket)}
+        onGenerateProposal={() =>
+          toast.info('Gerador de proposta', { description: 'Integração com mini simulador em breve.' })
+        }
+        typingIndicator={controller.typingIndicator}
+        quality={quality}
+        isSending={controller.sendMessageMutation.isPending}
+        sendError={controller.sendMessageMutation.error}
+      />
     </InboxAppShell>
   );
 };

--- a/apps/web/src/features/chat/components/ConversationArea/Composer.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/Composer.jsx
@@ -131,14 +131,14 @@ export const Composer = ({
   };
 
   return (
-    <div className="rounded-xl border border-slate-800/60 bg-slate-950/85 p-3">
+    <div className="rounded-[26px] bg-slate-950/25 p-4 shadow-[0_24px_56px_-34px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       {attachments.length > 0 ? (
         <div className="mb-3 flex flex-wrap gap-2">
           {attachments.map((file) => (
             <Badge
               key={file.id}
               variant="secondary"
-              className="flex items-center gap-2 border border-slate-700/70 bg-slate-900/80 text-[11px] text-slate-200"
+              className="flex items-center gap-2 bg-slate-900/40 text-[11px] text-slate-200 ring-1 ring-white/5"
             >
               <span>{file.name}</span>
               <span className="text-slate-400">{Math.round(file.size / 1024)} KB</span>
@@ -172,12 +172,12 @@ export const Composer = ({
                   return [...current, reply];
                 });
               }}
-              className="h-10 w-10 rounded-full border border-slate-800/60 bg-slate-950/60"
+              className="h-10 w-10 rounded-full bg-slate-900/40 ring-1 ring-white/5"
             />
             <Button
               variant="ghost"
               size="icon"
-              className="h-10 w-10 rounded-full border border-slate-800/60 bg-slate-950/60 text-slate-300 hover:bg-slate-900 hover:text-white"
+              className="h-10 w-10 rounded-full bg-slate-900/40 text-slate-300 ring-1 ring-white/5 transition hover:bg-slate-900/30 hover:text-white"
               onClick={handleAttachmentClick}
             >
               <Paperclip className="h-4 w-4" />
@@ -193,7 +193,7 @@ export const Composer = ({
             <Button
               variant="ghost"
               size="icon"
-              className="h-10 w-10 rounded-full border border-slate-800/60 bg-slate-950/60 text-slate-300 hover:bg-slate-900 hover:text-white"
+              className="h-10 w-10 rounded-full bg-slate-900/40 text-slate-300 ring-1 ring-white/5 transition hover:bg-slate-900/30 hover:text-white"
               onClick={() => setTemplatePickerOpen((open) => !open)}
             >
               <Smile className="h-4 w-4" />
@@ -202,7 +202,7 @@ export const Composer = ({
             <Button
               variant="ghost"
               size="icon"
-              className="h-10 w-10 rounded-full border border-slate-800/60 bg-slate-950/60 text-slate-300 hover:bg-slate-900 hover:text-white"
+              className="h-10 w-10 rounded-full bg-slate-900/40 text-slate-300 ring-1 ring-white/5 transition hover:bg-slate-900/30 hover:text-white"
               onClick={() => onRequestSuggestion?.()}
               disabled={aiLoading}
             >
@@ -233,12 +233,12 @@ export const Composer = ({
             }}
             disabled={(disabled && windowInfo?.isOpen !== false) || isSending}
             placeholder={placeholder}
-            className="min-h-[88px] flex-1 resize-none rounded-2xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 text-slate-100 placeholder:text-slate-600"
+            className="min-h-[88px] flex-1 resize-none rounded-[22px] border-none bg-slate-950/35 px-4 py-3 text-slate-100 placeholder:text-slate-500 ring-1 ring-white/5"
           />
           <Button
             variant="default"
             size="icon"
-            className="h-12 w-12 rounded-full bg-sky-600 text-white hover:bg-sky-500"
+            className="h-12 w-12 rounded-full bg-sky-500 text-white shadow-[0_18px_36px_-24px_rgba(14,165,233,0.7)] transition hover:bg-sky-400"
             disabled={(disabled && windowInfo?.isOpen !== false) || isSending}
             onClick={handleSend}
           >
@@ -249,18 +249,20 @@ export const Composer = ({
       </div>
 
       {windowInfo?.isOpen === false ? (
-        <div className="mt-2 flex items-center gap-2 text-xs text-amber-300">
+        <div className="mt-2 flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-200">
           <FileText className="h-4 w-4" />
           Janela de 24h expirada — envie um template aprovado para retomar a conversa.
         </div>
       ) : null}
 
       {sendError ? (
-        <div className="mt-2 text-xs text-rose-300">{sendError.message ?? 'Falha ao enviar mensagem.'}</div>
+        <div className="mt-2 rounded-md bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+          {sendError.message ?? 'Falha ao enviar mensagem.'}
+        </div>
       ) : null}
 
       {aiSuggestions.length > 0 ? (
-        <div className="mt-3 space-y-2 rounded-lg border border-slate-800/70 bg-slate-900/70 p-3 text-sm text-slate-200">
+        <div className="mt-3 space-y-2 rounded-2xl bg-slate-950/30 p-3 text-sm text-slate-200 ring-1 ring-white/5">
           <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
             <span>Sugestões da IA</span>
             <Button variant="ghost" size="sm" className="h-7 px-2 text-slate-400 hover:text-slate-100" onClick={onDiscardSuggestion}>
@@ -272,7 +274,7 @@ export const Composer = ({
               <button
                 key={`${index}-${suggestion.slice(0, 20)}`}
                 type="button"
-                className="w-full rounded-lg border border-slate-800/70 bg-slate-950/70 px-3 py-2 text-left text-xs transition hover:border-sky-500/50 hover:bg-slate-900"
+                className="w-full rounded-xl bg-slate-900/40 px-3 py-2 text-left text-xs text-slate-200 ring-1 ring-white/5 transition hover:bg-slate-900/30"
                 onClick={() => onApplySuggestion?.(suggestion)}
               >
                 {suggestion}

--- a/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
@@ -34,10 +34,10 @@ export const ConversationArea = ({
 
   useEffect(() => {
     ai.reset();
-  }, [ticket?.id]);
+  }, [ai, ticket?.id]);
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex h-full min-h-0 flex-col gap-6">
       <ConversationHeader
         ticket={ticket}
         onMarkWon={onMarkWon}
@@ -53,13 +53,15 @@ export const ConversationArea = ({
         quality={quality}
       />
 
-      <MessageTimeline
-        items={conversation.timeline}
-        loading={messagesQuery.isFetchingNextPage || messagesQuery.isFetchingPreviousPage}
-        hasMore={Boolean(messagesQuery.hasPreviousPage)}
-        onLoadMore={() => messagesQuery.fetchPreviousPage?.()}
-        typingAgents={typingIndicator?.agentsTyping ?? []}
-      />
+      <div className="flex min-h-0 flex-1 overflow-hidden rounded-[26px] bg-slate-950/20 shadow-inner shadow-slate-950/40 ring-1 ring-white/5 backdrop-blur-xl">
+        <MessageTimeline
+          items={conversation.timeline}
+          loading={messagesQuery.isFetchingNextPage || messagesQuery.isFetchingPreviousPage}
+          hasMore={Boolean(messagesQuery.hasPreviousPage)}
+          onLoadMore={() => messagesQuery.fetchPreviousPage?.()}
+          typingAgents={typingIndicator?.agentsTyping ?? []}
+        />
+      </div>
 
       <Composer
         disabled={disabled && !ticket?.window?.isOpen}

--- a/apps/web/src/features/chat/components/ConversationArea/ConversationHeader.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/ConversationHeader.jsx
@@ -16,7 +16,7 @@ export const ConversationHeader = ({
 }) => {
   if (!ticket) {
     return (
-      <div className="flex h-20 items-center justify-center rounded-xl border border-dashed border-slate-800/60 bg-slate-950/70 text-sm text-slate-400">
+      <div className="flex h-24 items-center justify-center rounded-[26px] bg-slate-950/25 text-sm text-slate-400 shadow-inner shadow-slate-950/40 ring-1 ring-white/5 backdrop-blur">
         Selecione um ticket para visualizar a conversa.
       </div>
     );
@@ -28,7 +28,7 @@ export const ConversationHeader = ({
   const remoteJid = ticket?.metadata?.whatsapp?.remoteJid || ticket?.metadata?.remoteJid || null;
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-slate-800/60 bg-slate-950/70 px-4 py-3">
+    <div className="flex flex-col gap-4 rounded-[26px] bg-slate-950/25 px-6 py-5 text-slate-100 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <div className="flex flex-col gap-1">
         <div className="flex flex-wrap items-center gap-2 text-lg font-semibold text-slate-100">
           <span>{name}</span>
@@ -43,10 +43,10 @@ export const ConversationHeader = ({
 
       <div className="flex flex-wrap items-center gap-2">
         {typingAgents.length > 0 ? (
-          <div className="flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/70 px-3 py-1 text-xs text-slate-200">
+          <div className="flex items-center gap-2 rounded-full bg-slate-900/40 px-3 py-1 text-xs text-slate-200 ring-1 ring-white/5">
             <div className="flex -space-x-2">
               {typingAgents.slice(0, 3).map((agent) => (
-                <Avatar key={agent.userId} className="h-6 w-6 border border-slate-900">
+                <Avatar key={agent.userId} className="h-6 w-6 border border-slate-900/40">
                   <AvatarFallback>{buildInitials(agent.userName, 'AG')}</AvatarFallback>
                 </Avatar>
               ))}
@@ -54,10 +54,10 @@ export const ConversationHeader = ({
             <span>{typingAgents[0].userName ?? 'Agente'} digitando…</span>
           </div>
         ) : null}
-        <Button size="sm" variant="secondary" onClick={() => onAssign?.(ticket)}>
+        <Button size="sm" variant="secondary" className="bg-slate-900/50 text-slate-100 hover:bg-slate-900/40" onClick={() => onAssign?.(ticket)}>
           Atribuir
         </Button>
-        <Button size="sm" variant="outline" onClick={() => onGenerateProposal?.(ticket)}>
+        <Button size="sm" variant="outline" className="border-transparent bg-slate-900/40 text-slate-200 hover:bg-slate-900/30" onClick={() => onGenerateProposal?.(ticket)}>
           Gerar proposta
         </Button>
         <Button size="sm" variant="default" className="bg-emerald-600 hover:bg-emerald-500" onClick={() => onMarkWon?.(ticket)}>
@@ -68,14 +68,14 @@ export const ConversationHeader = ({
         </Button>
       </div>
       <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
-        <Badge variant="outline" className="border-slate-800/60 bg-slate-900/60 text-[11px] text-slate-200">
+        <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-200 ring-1 ring-white/5">
           {phone}
         </Badge>
-        <Badge variant="outline" className="border-slate-800/60 bg-slate-900/60 text-[11px] text-slate-200">
+        <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-200 ring-1 ring-white/5">
           Documento: {document}
         </Badge>
         {remoteJid ? (
-          <Badge variant="outline" className="border-slate-800/60 bg-slate-900/60 text-[11px] text-slate-300">
+          <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-300 ring-1 ring-white/5">
             {remoteJid}
           </Badge>
         ) : null}

--- a/apps/web/src/features/chat/components/ConversationArea/MessageBubble.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/MessageBubble.jsx
@@ -21,9 +21,11 @@ const formatTime = (value) => {
 export const MessageBubble = ({ message }) => {
   const direction = message.direction ?? 'INBOUND';
   const outbound = direction === 'OUTBOUND';
-  const tone = outbound ? 'bg-sky-600/30 border-sky-500/40 text-slate-50' : 'bg-slate-900/80 border-slate-800/80 text-slate-100';
+  const tone = outbound
+    ? 'bg-sky-500/15 text-slate-50 ring-1 ring-sky-500/40'
+    : 'bg-slate-950/30 text-slate-100 ring-1 ring-white/5';
   const bubbleClass = cn(
-    'max-w-[75%] rounded-2xl border px-4 py-2 text-sm shadow-sm',
+    'max-w-[75%] rounded-[26px] px-4 py-3 text-sm leading-relaxed shadow-[0_20px_45px_-32px_rgba(15,23,42,0.9)] backdrop-blur',
     tone,
     outbound ? 'self-end rounded-tr-sm' : 'self-start rounded-tl-sm'
   );

--- a/apps/web/src/features/chat/components/ConversationArea/MessageTimeline.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/MessageTimeline.jsx
@@ -3,10 +3,10 @@ import MessageBubble from './MessageBubble.jsx';
 import EventCard from './EventCard.jsx';
 
 const Divider = ({ label }) => (
-  <div className="my-2 flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
-    <span className="h-px flex-1 bg-slate-800" />
-    <span>{label}</span>
-    <span className="h-px flex-1 bg-slate-800" />
+  <div className="my-4 flex items-center gap-2 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+    <span className="h-px flex-1 bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+    <span className="px-2 text-slate-300">{label}</span>
+    <span className="h-px flex-1 bg-gradient-to-l from-transparent via-white/10 to-transparent" />
   </div>
 );
 
@@ -46,17 +46,17 @@ export const MessageTimeline = ({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto pr-2"
+      className="flex-1 overflow-y-auto px-6 py-6"
       role="log"
       aria-live="polite"
       aria-relevant="additions"
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-4">
         {hasMore ? (
           <button
             type="button"
             onClick={() => onLoadMore?.()}
-            className="mx-auto mt-2 rounded-full border border-slate-700/70 px-4 py-1 text-xs text-slate-300 hover:border-slate-500"
+            className="mx-auto mt-2 rounded-full bg-slate-900/40 px-4 py-1 text-xs text-slate-300 ring-1 ring-white/5 transition hover:bg-slate-900/30"
           >
             {loading ? 'Carregando...' : 'Carregar anteriores'}
           </button>
@@ -75,7 +75,7 @@ export const MessageTimeline = ({
         })}
 
         {typingAgents.length > 0 ? (
-          <div className="flex items-center gap-2 text-xs text-emerald-200">
+          <div className="flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200">
             <div className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
             {typingAgents[0].userName ?? 'Agente'} digitando…
           </div>

--- a/apps/web/src/features/chat/components/ConversationArea/QuickActionsBar.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/QuickActionsBar.jsx
@@ -4,12 +4,12 @@ import { ShieldAlert, Sparkles, Repeat2 } from 'lucide-react';
 
 export const QuickActionsBar = ({ onReopenWindow, onMacro, quality }) => {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-800/60 bg-slate-950/80 px-4 py-2 text-xs text-slate-300">
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-[22px] bg-slate-950/25 px-5 py-3 text-xs text-slate-300 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <div className="flex items-center gap-2">
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="inline-flex items-center gap-1 rounded-md border border-slate-700/70 bg-slate-900/70 px-2 py-1">
+              <span className="inline-flex items-center gap-1 rounded-md bg-slate-900/40 px-3 py-1 text-slate-100 ring-1 ring-white/5">
                 <ShieldAlert className="h-3.5 w-3.5 text-amber-300" />
                 Qualidade WA: {quality?.qualityTier ?? '—'}
               </span>
@@ -22,10 +22,15 @@ export const QuickActionsBar = ({ onReopenWindow, onMacro, quality }) => {
       </div>
 
       <div className="flex items-center gap-2">
-        <Button size="sm" variant="outline" onClick={onMacro} className="border-slate-700/60 text-slate-200">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onMacro}
+          className="border-transparent bg-slate-900/40 text-slate-200 hover:bg-slate-900/30"
+        >
           <Sparkles className="mr-1 h-4 w-4" /> Aplicar macro
         </Button>
-        <Button size="sm" variant="secondary" onClick={onReopenWindow}>
+        <Button size="sm" variant="secondary" className="bg-sky-600/80 text-white hover:bg-sky-500/80" onClick={onReopenWindow}>
           <Repeat2 className="mr-1 h-4 w-4" /> Reabrir janela
         </Button>
       </div>

--- a/apps/web/src/features/chat/components/DetailsPanel/AuditTrailLink.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/AuditTrailLink.jsx
@@ -4,13 +4,17 @@ import { ExternalLink } from 'lucide-react';
 
 export const AuditTrailLink = ({ onOpenAudit }) => {
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="text-sm">Compliance & Auditoria</CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-3 text-xs text-slate-300">
         <p className="text-slate-400">Acesse relatórios, trilha de auditoria (CMN 4.935) e exportações para QA.</p>
-        <Button size="sm" variant="outline" className="justify-start gap-2 text-slate-200" onClick={onOpenAudit}>
+        <Button
+          size="sm"
+          className="justify-start gap-2 rounded-full bg-slate-900/40 text-slate-100 ring-1 ring-white/5 hover:bg-slate-900/30"
+          onClick={onOpenAudit}
+        >
           <ExternalLink className="h-4 w-4" /> Abrir auditoria completa
         </Button>
       </CardContent>

--- a/apps/web/src/features/chat/components/DetailsPanel/ConsentInfo.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/ConsentInfo.jsx
@@ -6,7 +6,7 @@ export const ConsentInfo = ({ consent }) => {
   }
   const grantedAt = consent.grantedAt ? new Date(consent.grantedAt).toLocaleString('pt-BR') : null;
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-200 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="text-sm">Consentimento</CardTitle>
       </CardHeader>

--- a/apps/web/src/features/chat/components/DetailsPanel/ContactDetailsCard.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/ContactDetailsCard.jsx
@@ -7,11 +7,11 @@ export const ContactDetailsCard = ({ contact }) => {
   }
 
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="text-sm">Contato</CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-2 text-xs text-slate-300">
         <div className="flex justify-between">
           <span>Telefone</span>
           <span>{formatPhoneNumber(contact.phone)}</span>

--- a/apps/web/src/features/chat/components/DetailsPanel/DetailsPanel.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/DetailsPanel.jsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+import { FileText, Repeat2, ShieldCheck, StickyNote } from 'lucide-react';
 import LeadSummaryCard from './LeadSummaryCard.jsx';
 import ContactDetailsCard from './ContactDetailsCard.jsx';
 import ConsentInfo from './ConsentInfo.jsx';
@@ -14,13 +16,63 @@ export const DetailsPanel = ({
   onReopenWindow,
   onOpenAudit,
 }) => {
+  const notesSectionRef = useRef(null);
+
+  const actions = [
+    {
+      label: 'Gerar minuta',
+      description: 'Resumo pré-aprovado com dados do lead',
+      icon: FileText,
+      onClick: () => onGenerateProposal?.(),
+      disabled: typeof onGenerateProposal !== 'function',
+    },
+    {
+      label: 'Reabrir janela',
+      description: 'Sugere template homologado',
+      icon: Repeat2,
+      onClick: () => onReopenWindow?.(),
+      disabled: typeof onReopenWindow !== 'function',
+    },
+    {
+      label: 'Abrir auditoria',
+      description: 'Compliance & trilha de eventos',
+      icon: ShieldCheck,
+      onClick: () => onOpenAudit?.(),
+      disabled: typeof onOpenAudit !== 'function',
+    },
+    {
+      label: 'Nova nota',
+      description: 'Registrar alinhamentos internos',
+      icon: StickyNote,
+      onClick: () => notesSectionRef.current?.focusComposer?.(),
+      disabled: false,
+    },
+  ];
+
   return (
-    <div className="flex h-full flex-col gap-4 overflow-y-auto pr-1">
+    <div className="flex h-full flex-col gap-6 overflow-y-auto pr-1">
+      <div className="grid grid-cols-2 gap-3">
+        {actions.map((action) => (
+          <button
+            type="button"
+            key={action.label}
+            onClick={action.onClick}
+            disabled={action.disabled}
+            className="group flex flex-col gap-2 rounded-3xl bg-slate-950/25 p-4 text-left shadow-[0_24px_50px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur transition hover:bg-slate-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-900/40 text-sky-300 shadow-inner shadow-slate-950/50">
+              <action.icon className="h-4 w-4" />
+            </span>
+            <span className="text-sm font-semibold text-slate-100">{action.label}</span>
+            <span className="text-xs text-slate-400">{action.description}</span>
+          </button>
+        ))}
+      </div>
       <LeadSummaryCard lead={ticket?.lead} />
       <ContactDetailsCard contact={ticket?.contact} />
       <ConsentInfo consent={ticket?.contact?.consent} />
       <ProposalMiniSim lead={ticket?.lead} onGenerate={onGenerateProposal} />
-      <NotesSection notes={ticket?.notes ?? []} onCreate={onCreateNote} loading={notesLoading} />
+      <NotesSection ref={notesSectionRef} notes={ticket?.notes ?? []} onCreate={onCreateNote} loading={notesLoading} />
       <TasksSection ticket={ticket} onReopenWindow={onReopenWindow} />
       <AuditTrailLink onOpenAudit={onOpenAudit} />
     </div>

--- a/apps/web/src/features/chat/components/DetailsPanel/LeadSummaryCard.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/LeadSummaryCard.jsx
@@ -4,7 +4,7 @@ import StatusBadge from '../Shared/StatusBadge.jsx';
 export const LeadSummaryCard = ({ lead }) => {
   if (!lead) {
     return (
-      <Card className="border-slate-800/60 bg-slate-950/80 text-slate-400">
+      <Card className="border-0 bg-slate-950/25 text-slate-400 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
         <CardHeader>
           <CardTitle className="text-sm text-slate-200">Resumo do lead</CardTitle>
         </CardHeader>
@@ -14,14 +14,14 @@ export const LeadSummaryCard = ({ lead }) => {
   }
 
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm">
           Resumo do lead
           <StatusBadge status={lead.status} />
         </CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-2 text-xs text-slate-300">
         <div className="flex justify-between">
           <span>Valor estimado</span>
           <span>{lead.value ? `R$ ${lead.value}` : '—'}</span>

--- a/apps/web/src/features/chat/components/DetailsPanel/NotesSection.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/NotesSection.jsx
@@ -1,11 +1,21 @@
-import { useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card.jsx';
 import { Textarea } from '@/components/ui/textarea.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { StickyNote } from 'lucide-react';
 
-export const NotesSection = ({ notes = [], onCreate, loading }) => {
+export const NotesSection = forwardRef(({ notes = [], onCreate, loading }, ref) => {
   const [value, setValue] = useState('');
+  const textareaRef = useRef(null);
+
+  useImperativeHandle(ref, () => ({
+    focusComposer: () => {
+      if (textareaRef.current) {
+        textareaRef.current.focus();
+        textareaRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    },
+  }));
 
   const handleSubmit = () => {
     const trimmed = value.trim();
@@ -15,19 +25,19 @@ export const NotesSection = ({ notes = [], onCreate, loading }) => {
   };
 
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm">
           <StickyNote className="h-4 w-4 text-amber-300" /> Notas internas
         </CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-3 text-xs text-slate-300">
         {notes.length === 0 ? (
           <p className="text-slate-500">Nenhuma nota registrada.</p>
         ) : (
           <div className="flex flex-col gap-2">
             {notes.map((note) => (
-              <div key={note.id} className="rounded-lg border border-slate-800/60 bg-slate-900/70 p-2">
+              <div key={note.id} className="rounded-2xl bg-slate-900/35 p-3 ring-1 ring-white/5">
                 <div className="flex justify-between text-[11px] text-slate-400">
                   <span>{note.authorName ?? 'Agente'}</span>
                   <span>{new Date(note.createdAt ?? note.updatedAt ?? Date.now()).toLocaleString('pt-BR')}</span>
@@ -40,17 +50,25 @@ export const NotesSection = ({ notes = [], onCreate, loading }) => {
       </CardContent>
       <CardFooter className="flex flex-col gap-2">
         <Textarea
+          ref={textareaRef}
           value={value}
           onChange={(event) => setValue(event.target.value)}
           placeholder="Adicionar nota interna (/nota)"
-          className="min-h-[80px] border-slate-800 bg-slate-900/70 text-slate-100"
+          className="min-h-[80px] rounded-[18px] border-none bg-slate-950/35 text-slate-100 placeholder:text-slate-500 ring-1 ring-white/5"
         />
-        <Button size="sm" onClick={handleSubmit} disabled={loading}>
+        <Button
+          size="sm"
+          className="w-full rounded-full bg-emerald-500 text-white shadow-[0_18px_36px_-24px_rgba(16,185,129,0.6)] hover:bg-emerald-400"
+          onClick={handleSubmit}
+          disabled={loading}
+        >
           Registrar nota
         </Button>
       </CardFooter>
     </Card>
   );
-};
+});
+
+NotesSection.displayName = 'NotesSection';
 
 export default NotesSection;

--- a/apps/web/src/features/chat/components/DetailsPanel/ProposalMiniSim.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/ProposalMiniSim.jsx
@@ -3,11 +3,11 @@ import { Button } from '@/components/ui/button.jsx';
 
 export const ProposalMiniSim = ({ lead, onGenerate }) => {
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="text-sm">Proposta rápida</CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-2 text-xs text-slate-300">
         <div className="flex justify-between">
           <span>Taxa alvo</span>
           <span>{lead?.metadata?.targetRate ?? '1,9% a.m.'}</span>
@@ -22,7 +22,7 @@ export const ProposalMiniSim = ({ lead, onGenerate }) => {
         </div>
       </CardContent>
       <CardFooter>
-        <Button className="w-full bg-sky-600 hover:bg-sky-500" size="sm" onClick={() => onGenerate?.()}>
+        <Button className="w-full rounded-full bg-sky-500 text-white shadow-[0_18px_36px_-24px_rgba(14,165,233,0.6)] hover:bg-sky-400" size="sm" onClick={() => onGenerate?.()}>
           Gerar minuta
         </Button>
       </CardFooter>

--- a/apps/web/src/features/chat/components/DetailsPanel/TasksSection.jsx
+++ b/apps/web/src/features/chat/components/DetailsPanel/TasksSection.jsx
@@ -14,18 +14,21 @@ export const TasksSection = ({ ticket, onReopenWindow }) => {
   const tasks = normalizeTasks(ticket);
 
   return (
-    <Card className="border-slate-800/60 bg-slate-950/80 text-slate-200">
+    <Card className="border-0 bg-slate-950/25 text-slate-100 shadow-[0_24px_45px_-32px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm">
           <CalendarClock className="h-4 w-4 text-sky-300" /> Tasks & Follow-ups
         </CardTitle>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-xs">
+      <CardContent className="flex flex-col gap-3 text-xs text-slate-300">
         {tasks.length === 0 ? (
           <p className="text-slate-500">Nenhum follow-up agendado.</p>
         ) : (
           tasks.map((task, index) => (
-            <div key={task.id ?? index} className="flex flex-col gap-1 rounded-lg border border-slate-800/60 bg-slate-900/70 p-2">
+            <div
+              key={task.id ?? index}
+              className="flex flex-col gap-1 rounded-2xl bg-slate-900/35 p-3 ring-1 ring-white/5"
+            >
               <div className="flex justify-between text-[11px] text-slate-400">
                 <span>{task.type ?? 'Follow-up'}</span>
                 <span>
@@ -43,7 +46,11 @@ export const TasksSection = ({ ticket, onReopenWindow }) => {
             </div>
           ))
         )}
-        <Button size="sm" variant="outline" onClick={onReopenWindow}>
+        <Button
+          size="sm"
+          className="w-full rounded-full bg-slate-900/40 text-slate-100 ring-1 ring-white/5 hover:bg-slate-900/30"
+          onClick={onReopenWindow}
+        >
           Reabrir janela com CTA
         </Button>
       </CardContent>

--- a/apps/web/src/features/chat/components/layout/ContextDrawer.jsx
+++ b/apps/web/src/features/chat/components/layout/ContextDrawer.jsx
@@ -4,22 +4,25 @@ import { useIsMobile } from '@/hooks/use-mobile.js';
 import { Drawer, DrawerContent } from '@/components/ui/drawer.jsx';
 import { ScrollArea } from '@/components/ui/scroll-area.jsx';
 
-const ContextDrawer = ({ open, onOpenChange, children }) => {
+const ContextDrawer = ({ open, onOpenChange, children, desktopClassName, desktopContentClassName }) => {
   const isMobile = useIsMobile();
 
   const content = useMemo(
     () => (
       <ScrollArea className="h-full">
-        <div className="min-h-full px-4 py-6 sm:px-5">{children}</div>
+        <div className={cn('min-h-full px-4 py-6 sm:px-5', desktopContentClassName)}>{children}</div>
       </ScrollArea>
     ),
-    [children]
+    [children, desktopContentClassName]
   );
 
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent side="right" className="border-slate-900/80 bg-slate-950 text-slate-100">
+        <DrawerContent
+          side="right"
+          className={cn('border-slate-900/50 bg-slate-950/90 text-slate-100 backdrop-blur-xl', desktopClassName)}
+        >
           {content}
         </DrawerContent>
       </Drawer>
@@ -29,8 +32,9 @@ const ContextDrawer = ({ open, onOpenChange, children }) => {
   return (
     <aside
       className={cn(
-        'relative hidden h-full flex-col border-l border-slate-900/70 bg-slate-950/80 transition-all duration-200 ease-linear lg:flex',
-        open ? 'w-[360px] opacity-100' : 'w-0 opacity-0'
+        'relative hidden h-full min-w-0 flex-col transition-all duration-200 ease-linear lg:flex',
+        desktopClassName,
+        open ? 'w-[360px] opacity-100' : 'pointer-events-none w-0 opacity-0'
       )}
     >
       <div className="pointer-events-auto h-full overflow-hidden">

--- a/apps/web/src/features/chat/components/layout/InboxAppShell.jsx
+++ b/apps/web/src/features/chat/components/layout/InboxAppShell.jsx
@@ -119,15 +119,13 @@ const InboxAppShell = ({
     [canPersistPreferences, updatePreferences]
   );
 
-  const listBorderClass = 'border-r border-slate-900/70';
-
   const renderListPane = useCallback(
     ({ showCloseButton = false } = {}) => (
       <div className="flex h-full flex-col">
-        <div className="px-4 py-4">
-          <div className="flex items-center justify-between gap-3 text-sm font-semibold text-slate-200">
+        <div className="px-5 pb-4 pt-5">
+          <div className="flex items-center justify-between gap-3 text-sm font-semibold text-slate-100">
             <div className="flex items-center gap-2">
-              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500/10 text-sky-300">
+              <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sky-500/15 text-sky-300 shadow-inner shadow-slate-950/50">
                 <MessageSquare className="h-4 w-4" />
               </span>
               <div className="space-y-0.5">
@@ -150,9 +148,9 @@ const InboxAppShell = ({
           </div>
         </div>
         <div className="flex-1 overflow-hidden">
-          <ScrollArea className="h-full pr-2">{sidebar}</ScrollArea>
+          <ScrollArea className="h-full px-2 pb-6">{sidebar}</ScrollArea>
         </div>
-        <div className="border-t border-slate-900/70 px-4 py-3 text-xs text-slate-500">
+        <div className="px-5 pb-5 pt-4 text-xs text-slate-500">
           <p className="font-medium text-slate-400">⌥ L alterna lista</p>
           <p className="mt-1 text-[11px] uppercase tracking-wide text-slate-600">
             {canPersistPreferences ? 'Preferência salva automaticamente' : 'Preferência local temporária'}
@@ -164,21 +162,36 @@ const InboxAppShell = ({
   );
 
   const headerListButtonLabel = desktopListVisible ? 'Ocultar lista' : 'Mostrar lista';
-  const detailSurface = (
-    <div className="flex min-h-0 flex-1 overflow-hidden bg-slate-950">
-      <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden', contextOpen ? 'lg:pr-0' : '')}>{children}</div>
-      <ContextDrawer open={contextOpen} onOpenChange={setContextOpen}>
-        {context}
-      </ContextDrawer>
-    </div>
-  );
+  const renderDetailSurface = () => {
+    const detailGap = contextOpen ? 'lg:gap-6' : 'lg:gap-0';
+
+    return (
+      <div className={cn('flex h-full min-h-0 w-full flex-col lg:flex-row', detailGap)}>
+        <div className="flex min-h-0 flex-1">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[32px] bg-slate-950/35 p-0 shadow-[0_30px_60px_-40px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur-xl">
+            <div className="flex min-h-0 flex-1 flex-col px-4 pb-5 pt-5 sm:px-6 lg:px-8">
+              {children}
+            </div>
+          </div>
+        </div>
+        <ContextDrawer
+          open={contextOpen}
+          onOpenChange={setContextOpen}
+          desktopClassName="rounded-[32px] bg-slate-950/40 shadow-[0_30px_60px_-45px_rgba(15,23,42,0.95)] ring-1 ring-white/5 backdrop-blur-xl"
+          desktopContentClassName="px-5 py-6"
+        >
+          {context}
+        </ContextDrawer>
+      </div>
+    );
+  };
 
   const listContent = renderListPane();
   const mobileListContent = renderListPane({ showCloseButton: true });
 
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-900/60 px-4 py-3">
+      <header className="flex flex-wrap items-center justify-between gap-3 bg-slate-950/85 px-4 py-3 shadow-[0_24px_48px_-36px_rgba(15,23,42,0.9)] supports-[backdrop-filter]:bg-slate-950/60 backdrop-blur-xl">
         <div className="flex items-center gap-3">
           <Button
             variant="ghost"
@@ -215,35 +228,41 @@ const InboxAppShell = ({
         </div>
       </header>
       {toolbar ? (
-        <div className="border-b border-slate-900/60 bg-slate-950/95 px-4 py-5">
+        <div className="bg-slate-950/80 px-4 py-4 shadow-[0_20px_48px_-36px_rgba(15,23,42,0.8)] supports-[backdrop-filter]:bg-slate-950/55 backdrop-blur-xl">
           <div className="mx-auto w-full max-w-6xl">
             {toolbar}
           </div>
         </div>
       ) : null}
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        {isDesktop ? (
-          <SplitLayout
-            className="min-h-0 flex-1"
-            list={listContent}
-            detail={detailSurface}
-            listPosition={effectiveListPosition}
-            listClassName={cn('bg-slate-950/90', listBorderClass)}
-            detailClassName="bg-slate-950"
-            listWidth={listWidth}
-            isListVisible={desktopListVisible && Boolean(sidebar)}
-            onListWidthChange={handleListWidthChange}
-            onListWidthCommit={handleListWidthCommit}
-            resizable={desktopListVisible && Boolean(sidebar)}
-          />
-        ) : (
-          detailSurface
-        )}
+        <div className="mx-auto flex h-full w-full max-w-7xl flex-1">
+          {isDesktop ? (
+            <SplitLayout
+              className="h-full w-full gap-6 px-4 pb-6 pt-4 sm:px-6 sm:pb-8 sm:pt-6"
+              list={listContent}
+              detail={renderDetailSurface()}
+              listPosition={effectiveListPosition}
+              listClassName={cn(
+                'flex flex-col overflow-hidden rounded-[28px] bg-slate-950/75 shadow-[0_24px_56px_-34px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur-xl'
+              )}
+              detailClassName="min-h-0 min-w-0"
+              listWidth={listWidth}
+              isListVisible={desktopListVisible && Boolean(sidebar)}
+              onListWidthChange={handleListWidthChange}
+              onListWidthCommit={handleListWidthCommit}
+              resizable={desktopListVisible && Boolean(sidebar)}
+            />
+          ) : (
+            <div className="flex h-full w-full px-4 pb-6 pt-4 sm:px-6 sm:pb-8 sm:pt-6">
+              {renderDetailSurface()}
+            </div>
+          )}
+        </div>
       </div>
       <Sheet open={mobileListOpen} onOpenChange={setMobileListOpen}>
         <SheetContent
           side="left"
-          className={cn('w-[min(420px,90vw)] border-slate-900/70 bg-slate-950/95 p-0 text-slate-100', 'border-r')}
+          className={cn('w-[min(420px,90vw)] border-slate-900/40 bg-slate-950/90 p-0 text-slate-100 backdrop-blur-xl', 'border-r')}
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Lista de tickets</SheetTitle>


### PR DESCRIPTION
## Summary
- restructure the inbox shell to separate the ticket list, conversation timeline, and lead context into three translucent panels
- refresh conversation components with neutral backgrounds, rounded surfaces, and subtle status indicators
- modernize the lead details drawer with an action grid, modular cards, and reusable focus behavior for notes

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68e55acab43c833294af77d4fc93b3fc