### PR TITLE
Refine inbox typography hierarchy for leads view

### DIFF
--- a/apps/web/src/features/chat/components/SidebarInbox/InboxFilters.jsx
+++ b/apps/web/src/features/chat/components/SidebarInbox/InboxFilters.jsx
@@ -62,12 +62,12 @@ export const InboxFilters = ({
           value={search}
           onChange={(event) => onSearchChange?.(event.target.value)}
           placeholder="Buscar por nome, telefone, CPF, matrícula, ID..."
-          className="flex-1 bg-slate-900/70 text-slate-100 placeholder:text-slate-500"
+          className="flex-1 bg-slate-900/70 text-[13px] text-foreground placeholder:text-muted-foreground/60"
         />
         <Button
           variant="outline"
           size="sm"
-          className="border-slate-700/60 bg-slate-900/70 text-slate-200"
+          className="border-slate-700/60 bg-slate-900/70 text-[13px] font-semibold text-sky-200"
           onClick={onRefresh}
           disabled={loading}
         >
@@ -76,9 +76,9 @@ export const InboxFilters = ({
         </Button>
       </div>
 
-      <div className="flex flex-wrap gap-3 text-xs text-slate-300">
+      <div className="flex flex-wrap gap-3 text-[13px] text-muted-foreground/80">
         <div className="flex flex-col gap-1">
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Responsável</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground/70">Responsável</span>
           <ToggleGroup
             type="single"
             value={filters.scope}
@@ -96,7 +96,7 @@ export const InboxFilters = ({
         </div>
 
         <div className="flex flex-col gap-1">
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Janela</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground/70">Janela</span>
           <ToggleGroup
             type="single"
             value={filters.window}
@@ -114,7 +114,7 @@ export const InboxFilters = ({
         </div>
 
         <div className="flex flex-col gap-1">
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Resultado</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground/70">Resultado</span>
           <ToggleGroup
             type="single"
             value={filters.outcome ?? undefined}

--- a/apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx
+++ b/apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx
@@ -50,26 +50,26 @@ export const InboxItem = ({
       type="button"
       onClick={() => onSelect?.(ticket.id)}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-xl border border-slate-800/70 bg-slate-950/75 p-3 text-left transition hover:border-slate-600/70 hover:bg-slate-900',
-        selected && 'border-sky-500/60 bg-slate-900'
+        'flex w-full flex-col gap-3 rounded-xl border border-slate-800/70 bg-slate-950/75 p-3 text-left transition hover:border-sky-500/40 hover:bg-slate-900',
+        selected && 'border-sky-500/80 bg-slate-900'
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <span className="rounded-full bg-slate-800/80 p-2 text-sky-300">
+        <div className="flex items-center gap-3">
+          <span className="rounded-full bg-slate-900/80 p-2 text-sky-300">
             <ChannelIcon className="h-4 w-4" />
           </span>
-          <div>
-            <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
-              <span className="truncate max-w-[160px]" title={name}>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-base font-semibold text-foreground">
+              <span className="max-w-[180px] truncate" title={name}>
                 {name}
               </span>
               <StatusBadge status={ticket.status} />
             </div>
-            <div className="mt-1 flex items-center gap-2 text-xs text-slate-400">
+            <div className="flex items-center gap-2 text-[11px] font-medium text-muted-foreground/70">
               <PipelineStepTag step={ticket.pipelineStep ?? ticket.metadata?.pipelineStep} />
               {ticket.timeline?.unreadInboundCount ? (
-                <Badge variant="secondary" className="bg-emerald-500/20 text-emerald-200">
+                <Badge variant="secondary" className="border border-emerald-500/60 bg-emerald-500/10 text-[11px] font-medium text-emerald-300">
                   {ticket.timeline.unreadInboundCount} novas
                 </Badge>
               ) : null}
@@ -100,35 +100,35 @@ export const InboxItem = ({
         />
       </div>
 
-      <div className="flex items-center gap-2 text-xs text-slate-300">
+      <div className="flex items-center gap-2 text-[13px] text-muted-foreground/80">
         <SlaBadge window={ticket.window} />
         {ticket.qualityScore !== null && ticket.qualityScore !== undefined ? (
-          <Badge variant="outline" className="border border-emerald-500/50 bg-emerald-500/10 text-emerald-200">
+          <Badge variant="outline" className="border border-emerald-500/50 bg-emerald-500/10 text-[11px] font-medium text-emerald-300">
             Qualidade {ticket.qualityScore}%
           </Badge>
         ) : null}
         {ticket.lead?.probability ? (
-          <Badge variant="outline" className="border border-sky-500/50 bg-sky-500/10 text-sky-200">
+          <Badge variant="outline" className="border border-sky-500/50 bg-sky-500/10 text-[11px] font-medium text-sky-200">
             {ticket.lead.probability}% chance
           </Badge>
         ) : null}
       </div>
 
-      <div className="text-xs text-slate-400">
-        {typingLabel ? <span className="text-emerald-200">{typingLabel}</span> : formatPreview(ticket)}
+      <div className="text-[13px] text-muted-foreground/80">
+        {typingLabel ? <span className="font-medium text-emerald-300">{typingLabel}</span> : formatPreview(ticket)}
       </div>
 
-      <div className="flex items-center gap-2 text-xs text-slate-400">
-        <div className="flex items-center gap-1">
-          <Avatar className="h-6 w-6 border border-slate-700/70">
+      <div className="flex items-center gap-2 text-[11px] font-medium text-muted-foreground/70">
+        <div className="flex items-center gap-1.5 text-[13px] font-normal text-muted-foreground/80">
+          <Avatar className="h-6 w-6 border border-slate-800/70">
             <AvatarImage src={ticket.contact?.avatar} alt={name} />
             <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
-          {ticket.userId ? <span>Atribuído</span> : <span>Não atribuído</span>}
+          {ticket.userId ? <span className="text-[13px] text-muted-foreground/80">Atribuído</span> : <span className="text-[13px] text-muted-foreground/80">Não atribuído</span>}
         </div>
-        {phoneLabel ? <span className="text-slate-500">{phoneLabel}</span> : null}
+        {phoneLabel ? <span className="text-[11px] font-medium text-muted-foreground/70">{phoneLabel}</span> : null}
         {ticket.timeline?.lastInboundAt ? (
-          <span>
+          <span className="text-[11px] font-medium text-muted-foreground/70">
             Último cliente: {new Date(ticket.timeline.lastInboundAt).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
           </span>
         ) : null}

--- a/apps/web/src/features/chat/components/SidebarInbox/InboxPanel.jsx
+++ b/apps/web/src/features/chat/components/SidebarInbox/InboxPanel.jsx
@@ -18,36 +18,36 @@ const MetricsCard = ({ metrics }) => {
   }
 
   return (
-    <div className="rounded-xl border border-slate-800/60 bg-slate-950/70 p-3 text-xs text-slate-300">
+    <div className="rounded-xl border border-slate-800/60 bg-slate-950/70 p-3">
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">FRT &lt; 5 min</span>
-          <p className="text-lg font-semibold text-slate-100">
+        <div className="space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">FRT &lt; 5 min</span>
+          <p className="text-base font-bold text-foreground">
             {metrics.firstResponse?.underFiveMinutesRate !== null && metrics.firstResponse?.underFiveMinutesRate !== undefined
               ? `${Math.round((metrics.firstResponse.underFiveMinutesRate ?? 0) * 100)}%`
               : '—'}
           </p>
         </div>
-        <div>
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Entropia status</span>
-          <p className="text-lg font-semibold text-slate-100">
+        <div className="space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">Entropia status</span>
+          <p className="text-base font-bold text-foreground">
             {metrics.statusEntropy ?? '—'}
           </p>
         </div>
-        <div>
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Proposta → CCB</span>
-          <p className="text-lg font-semibold text-slate-100">
+        <div className="space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">Proposta → CCB</span>
+          <p className="text-base font-bold text-foreground">
             {metrics.proposalToCcbRate !== null && metrics.proposalToCcbRate !== undefined
               ? `${Math.round((metrics.proposalToCcbRate ?? 0) * 100)}%`
               : '—'}
           </p>
         </div>
-        <div>
-          <span className="text-[11px] uppercase tracking-[0.2em] text-slate-500">Qualidade WA</span>
-          <p className="text-lg font-semibold text-slate-100">
+        <div className="space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">Qualidade WA</span>
+          <p className="text-base font-bold text-foreground">
             {metrics.whatsappQuality?.qualityTier ? metrics.whatsappQuality.qualityTier : '—'}
           </p>
-          <p className="text-[11px] text-slate-500">
+          <p className="text-[11px] font-medium text-muted-foreground/70">
             Limite: {metrics.whatsappQuality?.throughputLimit ?? '—'} msgs/dia
           </p>
         </div>
@@ -91,9 +91,10 @@ export const InboxPanel = ({
 
       <div className="flex-1 overflow-y-auto pr-1">
         {tickets.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center rounded-xl border border-dashed border-slate-800/70 bg-slate-950/70 p-6 text-center text-sm text-slate-400">
-            <p>Nenhum ticket encontrado com os filtros selecionados.</p>
-            <p className="text-xs text-slate-500">Ajuste os filtros ou pesquise por outro contato.</p>
+          <div className="flex h-full flex-col items-center justify-center rounded-xl border border-dashed border-slate-800/70 bg-slate-950/70 p-6 text-center text-[13px] text-muted-foreground/80">
+            <p className="text-base font-bold text-foreground">Nada por aqui ainda</p>
+            <p className="text-[13px] text-muted-foreground/80">Nenhum ticket encontrado com os filtros selecionados.</p>
+            <p className="text-[11px] font-medium text-muted-foreground/70">Ajuste os filtros ou pesquise por outro contato.</p>
           </div>
         ) : (
           <div className="flex flex-col gap-2">

--- a/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
@@ -7,17 +7,14 @@ import {
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
-import { cn } from '@/lib/utils.js';
 import { MessageSquare } from 'lucide-react';
 
-export const InboxHeader = ({
-  stepLabel,
-  campaign,
-  onboarding,
-}) => {
+export const InboxHeader = ({ stepLabel, campaign, onboarding }) => {
   const activeStep = onboarding?.activeStep ?? 0;
   const nextStage = onboarding?.stages?.[activeStep + 1]?.title ?? 'Relatórios';
+  const leadCount = onboarding?.metrics?.inboxCount ?? null;
   const campaignName = campaign?.name;
+  const hasLeadCount = typeof leadCount === 'number';
 
   const breadcrumbItems = [
     { label: 'Leads', href: '#leads' },
@@ -25,75 +22,71 @@ export const InboxHeader = ({
   ];
 
   return (
-    <div className="space-y-5">
-      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.26em] text-muted-foreground/70">
-        <Badge
-          variant="outline"
-          className="border-border/60 bg-transparent px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground"
-        >
-          {stepLabel}
-        </Badge>
-        <span className="text-[11px] font-medium text-muted-foreground/75">Fluxo concluído</span>
+    <header className="space-y-6">
+      <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground/70">
+        {stepLabel ? (
+          <Badge
+            variant="outline"
+            className="border-border/60 bg-transparent px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground/80"
+          >
+            {stepLabel}
+          </Badge>
+        ) : null}
+        <span className="text-muted-foreground/70">Fluxo concluído</span>
       </div>
 
-      <div className="flex flex-col gap-4">
-        <Breadcrumb className="text-xs text-muted-foreground/65">
-          <BreadcrumbList>
-            {breadcrumbItems.map((item, index) => (
-              <BreadcrumbItem key={item.label}>
-                {item.current ? (
-                  <BreadcrumbPage className="text-sm font-medium text-foreground/85">
-                    {item.label}
-                  <BreadcrumbPage className="flex items-center gap-1.5 text-sm font-medium text-foreground/90">
-                    {item.icon ? <item.icon className="h-3.5 w-3.5 text-muted-foreground/70" aria-hidden /> : null}
-                    <span>{item.label}</span>
-                  </BreadcrumbPage>
-                ) : (
-                  <BreadcrumbLink
-                    href={item.href}
-                    className="text-xs font-medium text-muted-foreground/75 hover:text-foreground/85"
-                  >
-                    {item.label}
-                  </BreadcrumbLink>
-                )}
-                {index < breadcrumbItems.length - 1 ? <BreadcrumbSeparator /> : null}
-              </BreadcrumbItem>
-            ))}
-          </BreadcrumbList>
-        </Breadcrumb>
+      <Breadcrumb className="text-[11px] font-medium text-muted-foreground/70">
+        <BreadcrumbList>
+          {breadcrumbItems.map((item, index) => (
+            <BreadcrumbItem key={item.label}>
+              {item.current ? (
+                <BreadcrumbPage className="flex items-center gap-1.5 text-sm font-semibold text-foreground/85">
+                  {item.icon ? <item.icon className="h-3.5 w-3.5 text-muted-foreground/65" aria-hidden /> : null}
+                  <span>{item.label}</span>
+                </BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink
+                  href={item.href}
+                  className="text-[11px] font-medium text-muted-foreground/70 hover:text-foreground/80"
+                >
+                  {item.label}
+                </BreadcrumbLink>
+              )}
+              {index < breadcrumbItems.length - 1 ? <BreadcrumbSeparator /> : null}
+            </BreadcrumbItem>
+          ))}
+        </BreadcrumbList>
+      </Breadcrumb>
 
-        <div className="flex flex-wrap items-start justify-between gap-6">
-          <div className="space-y-2">
-            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-              Inbox de Leads
-            </h1>
-            <p className="max-w-xl text-sm leading-relaxed text-muted-foreground/90">
-              Leads do convênio {agreementName ?? 'selecionado'} sincronizados automaticamente após cada mensagem no WhatsApp
-              conectado.
-            </p>
-          </div>
-          <div className="flex flex-col items-end gap-1 rounded-2xl border border-white/5 bg-white/[0.04] px-4 py-3 text-right text-xs text-muted-foreground/80">
-            <p className="text-[11px] font-medium uppercase tracking-[0.26em] text-muted-foreground/70">Status atual</p>
-            <p className="text-base font-semibold text-foreground/90">{leadCount} leads ativos</p>
-            <p className="text-[12px] text-muted-foreground/70">Próximo passo: {nextStage}</p>
-          </div>
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <h1 className="text-[1.625rem] font-semibold leading-tight tracking-tight text-foreground">Inbox de Leads</h1>
-          <p className="text-xs text-muted-foreground/80">Próximo passo: {nextStage}</p>
+      <div className="flex flex-wrap items-start justify-between gap-6">
+        <div className="space-y-2">
+          <h1 className="text-base font-bold text-foreground">Inbox de Leads</h1>
+          <p className="text-sm font-semibold text-muted-foreground/80">
+            Organize e priorize as conversas do seu time em um só lugar.
+          </p>
+          <p className="max-w-xl text-[13px] text-muted-foreground/80">
+            Respostas rápidas mantêm a confiança do lead. Acompanhe métricas e prossiga para {nextStage.toLowerCase()} quando estiver tudo pronto.
+          </p>
+        </div>
+
+        <div className="flex flex-col items-end gap-1 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-right">
+          <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground/70">Status atual</p>
+          <p className="text-base font-semibold text-emerald-300">
+            {hasLeadCount ? `${leadCount} leads ativos` : 'Monitorando leads'}
+          </p>
+          <p className="text-[13px] text-muted-foreground/80">Próximo passo: {nextStage}</p>
         </div>
       </div>
 
       {campaignName ? (
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground/80">
-          <span className="font-medium text-foreground/80">Campanha ativa</span>
-          <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-            <span className={cn('rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-medium text-foreground/85')}>
-              {campaignName}
-            </span>
-          </div>
+        <div className="flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground/80">
+          <span className="text-sm font-semibold text-muted-foreground/90">Campanha ativa</span>
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-medium text-muted-foreground/80">
+            {campaignName}
+          </span>
         </div>
       ) : null}
-    </div>
+    </header>
   );
 };
 


### PR DESCRIPTION
## Summary
- update the inbox header to follow the new typographic scale and color intent guidelines
- restyle lead cards, filters, and metrics with clearer hierarchy and contextual labels
- refresh empty states and action highlights with consistent body and label treatments

## Testing
- pnpm --filter web dev *(fails: dependency resolution warning for @tanstack/query-core, server still served UI)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c550ef48332b1a34720f3b5e501