### PR TITLE
Hide onboarding track on lead inbox

### DIFF
--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -82,6 +82,8 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
     }
   }, [sidebarOpen]);
 
+  const shouldShowOnboardingTrack = stageList.length > 0 && currentPage !== 'inbox';
+
   return (
     <div className="layout-container">
       <aside
@@ -189,7 +191,7 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
 
         <main className="page-content">
           <div className="page-content-inner">
-            {stageList.length > 0 ? (
+            {shouldShowOnboardingTrack ? (
               <div className="onboarding-track" aria-label="Progresso do onboarding">
                 {stageList.map((stage, index) => {
                   const status =


### PR DESCRIPTION
## Summary
- stop rendering the onboarding progress pills when viewing the lead inbox

## Testing
- pnpm --filter web dev

------
https://chatgpt.com/codex/tasks/task_e_68e5601f66208332a2292698e7a9aa8e