### PR TITLE
Remove reopen window quick action

### DIFF
--- a/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
@@ -47,11 +47,7 @@ export const ConversationArea = ({
         typingAgents={typingIndicator?.agentsTyping ?? []}
       />
 
-      <QuickActionsBar
-        onReopenWindow={() => onGenerateProposal?.('reopen-window')}
-        onMacro={() => onSendMessage?.('Aplicando macro padrão...')}
-        quality={quality}
-      />
+      <QuickActionsBar onMacro={() => onSendMessage?.('Aplicando macro padrão...')} quality={quality} />
 
       <div className="flex min-h-0 flex-1 overflow-hidden rounded-[26px] bg-slate-950/20 shadow-inner shadow-slate-950/40 ring-1 ring-white/5 backdrop-blur-xl">
         <MessageTimeline

--- a/apps/web/src/features/chat/components/ConversationArea/QuickActionsBar.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/QuickActionsBar.jsx
@@ -1,8 +1,8 @@
 import { Button } from '@/components/ui/button.jsx';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.jsx';
-import { ShieldAlert, Sparkles, Repeat2 } from 'lucide-react';
+import { ShieldAlert, Sparkles } from 'lucide-react';
 
-export const QuickActionsBar = ({ onReopenWindow, onMacro, quality }) => {
+export const QuickActionsBar = ({ onMacro, quality }) => {
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-[22px] bg-slate-950/25 px-5 py-3 text-xs text-slate-300 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
       <div className="flex items-center gap-2">
@@ -29,9 +29,6 @@ export const QuickActionsBar = ({ onReopenWindow, onMacro, quality }) => {
           className="border-transparent bg-slate-900/40 text-slate-200 hover:bg-slate-900/30"
         >
           <Sparkles className="mr-1 h-4 w-4" /> Aplicar macro
-        </Button>
-        <Button size="sm" variant="secondary" className="bg-sky-600/80 text-white hover:bg-sky-500/80" onClick={onReopenWindow}>
-          <Repeat2 className="mr-1 h-4 w-4" /> Reabrir janela
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the reopen window button from the chat quick actions bar
- update the conversation area to stop passing the reopen handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5636783e883329da7a41bf3c03b46