### PR TITLE
Revamp chat conversation header layout and actions

### DIFF
--- a/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/ConversationArea.jsx
@@ -11,10 +11,11 @@ export const ConversationArea = ({
   messagesQuery,
   onSendMessage,
   onCreateNote,
-  onMarkWon,
-  onMarkLost,
+  onRegisterResult,
   onAssign,
   onGenerateProposal,
+  onScheduleFollowUp,
+  isRegisteringResult = false,
   typingIndicator,
   quality,
   isSending,
@@ -40,10 +41,11 @@ export const ConversationArea = ({
     <div className="flex h-full min-h-0 flex-col gap-6">
       <ConversationHeader
         ticket={ticket}
-        onMarkWon={onMarkWon}
-        onMarkLost={onMarkLost}
+        onRegisterResult={onRegisterResult}
         onAssign={onAssign}
         onGenerateProposal={onGenerateProposal}
+        onScheduleFollowUp={onScheduleFollowUp}
+        isRegisteringResult={isRegisteringResult}
         typingAgents={typingIndicator?.agentsTyping ?? []}
       />
 

--- a/apps/web/src/features/chat/components/ConversationArea/ConversationHeader.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/ConversationHeader.jsx
@@ -1,85 +1,521 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.jsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog.jsx';
 import { Button } from '@/components/ui/button.jsx';
-import StatusBadge from '../Shared/StatusBadge.jsx';
-import PipelineStepTag from '../Shared/PipelineStepTag.jsx';
-import SlaBadge from '../SidebarInbox/SlaBadge.jsx';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar.jsx';
-import { Badge } from '@/components/ui/badge.jsx';
-import { formatPhoneNumber, buildInitials } from '@/lib/utils.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.jsx';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.jsx';
+import { Label } from '@/components/ui/label.jsx';
+import { Textarea } from '@/components/ui/textarea.jsx';
+import { cn, formatPhoneNumber, buildInitials } from '@/lib/utils.js';
+import { toast } from 'sonner';
+import { ChevronDown, IdCard, Phone } from 'lucide-react';
+
+const LOSS_REASONS = [
+  { value: 'sem_interesse', label: 'Sem interesse' },
+  { value: 'orcamento', label: 'Sem orçamento disponível' },
+  { value: 'concorrencia', label: 'Fechou com a concorrência' },
+  { value: 'documentacao', label: 'Documentação incompleta' },
+  { value: 'outro', label: 'Outro' },
+];
+
+const RESULT_ITEMS = [
+  { value: 'won', label: 'Ganho' },
+  { value: 'lost', label: 'Perda' },
+  { value: 'no_contact', label: 'Sem contato' },
+  { value: 'disqualified', label: 'Desqualificado' },
+];
+
+const STATUS_LABELS = {
+  OPEN: 'Aberto',
+  PENDING: 'Pendente',
+  ASSIGNED: 'Em atendimento',
+  RESOLVED: 'Resolvido',
+  CLOSED: 'Fechado',
+};
+
+const STATUS_TONE = {
+  OPEN: 'info',
+  PENDING: 'info',
+  ASSIGNED: 'info',
+  RESOLVED: 'success',
+  CLOSED: 'neutral',
+};
+
+const CHIP_STYLES = {
+  info: 'border border-sky-400/70 text-sky-100',
+  warning: 'border border-amber-400/30 bg-amber-400/15 text-amber-100',
+  danger: 'border border-rose-400/30 bg-rose-500/15 text-rose-100',
+  neutral: 'border border-white/12 text-white/80',
+  success: 'border border-emerald-400/40 text-emerald-100',
+};
+
+const LOSS_REASON_HELPERS = LOSS_REASONS.reduce((acc, item) => {
+  acc[item.value] = item.label;
+  return acc;
+}, {});
+
+const formatPotential = (value) => {
+  if (value === null || value === undefined) return 'R$ —';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) {
+    return `R$ ${value}`;
+  }
+  return `R$ ${numeric.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`;
+};
+
+const formatProbability = (value) => {
+  if (value === null || value === undefined) return '—';
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value);
+  return `${Math.round(numeric)}%`;
+};
+
+const getStatusInfo = (status) => {
+  const normalized = status ? String(status).toUpperCase() : 'OPEN';
+  return {
+    label: STATUS_LABELS[normalized] ?? normalized,
+    tone: STATUS_TONE[normalized] ?? 'neutral',
+  };
+};
+
+const minutesToHoursLabel = (minutes) => {
+  if (minutes === undefined || minutes === null) return null;
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.round(minutes / 60);
+  return `${hours} h`;
+};
+
+const getExpirationInfo = (windowInfo = {}) => {
+  const { remainingMinutes, isOpen } = windowInfo;
+
+  if (isOpen === false) {
+    return { label: 'Janela expirada', tone: 'danger' };
+  }
+
+  if (remainingMinutes === undefined || remainingMinutes === null) {
+    return { label: 'Expira em breve', tone: 'warning' };
+  }
+
+  if (remainingMinutes <= 120) {
+    const label = remainingMinutes <= 60
+      ? `Expira em ${remainingMinutes} min`
+      : `Expira em ${Math.round(remainingMinutes / 60)} h`;
+    return { label, tone: 'danger' };
+  }
+
+  if (remainingMinutes < 1440) {
+    const label = remainingMinutes <= 180
+      ? `Expira em ${Math.round(remainingMinutes / 60)} h`
+      : 'Expira em 24h';
+    return { label, tone: 'warning' };
+  }
+
+  const days = Math.floor(remainingMinutes / 1440);
+  return { label: `Expira em ${days}d`, tone: 'warning' };
+};
+
+const buildSlaTooltip = (windowInfo = {}) => {
+  const lastInteraction = minutesToHoursLabel(windowInfo.lastInteractionMinutes);
+  if (!lastInteraction) {
+    return 'Prazo para primeira resposta.';
+  }
+  return `Prazo para primeira resposta. Último contato há ${lastInteraction}.`;
+};
+
+const Chip = ({ tone = 'neutral', className, children, ...props }) => (
+  <span
+    className={cn(
+      'inline-flex min-h-[28px] items-center justify-center rounded-full px-3 text-[12px] font-medium leading-none tracking-wide',
+      CHIP_STYLES[tone] ?? CHIP_STYLES.neutral,
+      className,
+    )}
+    {...props}>
+    {children}
+  </span>
+);
+
+const TypingIndicator = ({ agents = [] }) => {
+  if (!agents.length) return null;
+  const label = agents[0]?.userName ?? 'Agente';
+  return (
+    <div className="inline-flex min-h-[28px] items-center gap-2 rounded-full border border-white/12 bg-white/8 px-3 text-[12px] text-white/80">
+      <div className="flex -space-x-2">
+        {agents.slice(0, 3).map((agent) => (
+          <Avatar key={agent.userId} className="h-6 w-6 border border-slate-900/40">
+            <AvatarFallback>{buildInitials(agent.userName, 'AG')}</AvatarFallback>
+          </Avatar>
+        ))}
+      </div>
+      <span>{label} digitando…</span>
+    </div>
+  );
+};
+
+const MetadataBadge = ({ icon: Icon, children, className, ...props }) => (
+  <button
+    type="button"
+    className={cn(
+      'inline-flex min-h-[44px] items-center gap-2 rounded-xl border border-white/10 bg-white/8 px-3 text-sm font-medium text-white/80 transition-colors hover:bg-white/12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40',
+      className,
+    )}
+    {...props}>
+    {Icon ? <Icon className="size-4" aria-hidden /> : null}
+    <span className="truncate text-left">{children}</span>
+  </button>
+);
 
 export const ConversationHeader = ({
   ticket,
-  onMarkWon,
-  onMarkLost,
+  onRegisterResult,
   onAssign,
   onGenerateProposal,
+  onScheduleFollowUp,
   typingAgents = [],
+  isRegisteringResult = false,
 }) => {
+  const [isFadeIn, setIsFadeIn] = useState(true);
+  const [resultSelection, setResultSelection] = useState('');
+  const [lossDialogOpen, setLossDialogOpen] = useState(false);
+  const [lossReason, setLossReason] = useState('');
+  const [lossNotes, setLossNotes] = useState('');
+  const [lossSubmitted, setLossSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!ticket) return;
+    setIsFadeIn(false);
+    const frame = requestAnimationFrame(() => setIsFadeIn(true));
+    return () => cancelAnimationFrame(frame);
+  }, [ticket?.id, ticket]);
+
+  const name = ticket?.contact?.name ?? ticket?.subject ?? 'Contato sem nome';
+  const company = ticket?.metadata?.company ?? ticket?.contact?.company;
+  const title = company ? `${name} | ${company}` : name;
+  const phoneDisplay = formatPhoneNumber(ticket?.contact?.phone || ticket?.metadata?.contactPhone);
+  const rawPhone = ticket?.contact?.phone || ticket?.metadata?.contactPhone || null;
+  const document = ticket?.contact?.document ?? '—';
+
+  const statusInfo = useMemo(() => getStatusInfo(ticket?.status), [ticket?.status]);
+  const expirationInfo = useMemo(() => getExpirationInfo(ticket?.window), [ticket?.window]);
+  const slaTooltip = useMemo(() => buildSlaTooltip(ticket?.window), [ticket?.window]);
+
+  const subtitle = useMemo(() => {
+    const id = ticket?.lead?.id ?? ticket?.id ?? '—';
+    const potential = formatPotential(ticket?.lead?.value);
+    const probability = formatProbability(ticket?.lead?.probability);
+    const stage = ticket?.pipelineStep ?? ticket?.metadata?.pipelineStep ?? '—';
+    return `ID #${id} • Potencial ${potential} • Prob. ${probability} • Etapa: ${stage}`;
+  }, [ticket?.lead?.id, ticket?.lead?.value, ticket?.lead?.probability, ticket?.pipelineStep, ticket?.metadata?.pipelineStep, ticket?.id]);
+
+  const resetLossState = useCallback(() => {
+    setLossReason('');
+    setLossNotes('');
+    setLossSubmitted(false);
+  }, []);
+
+  const handleResult = useCallback(async (value, reason) => {
+    if (!onRegisterResult) {
+      toast.error('Não foi possível concluir. Tente novamente.');
+      return;
+    }
+
+    setResultSelection(value);
+    try {
+      await onRegisterResult({ outcome: value === 'won' ? 'won' : 'lost', reason });
+    } finally {
+      setResultSelection('');
+    }
+  }, [onRegisterResult]);
+
+  const handleResultChange = useCallback(async (value) => {
+    if (!value) return;
+    if (value === 'lost') {
+      setLossDialogOpen(true);
+      return;
+    }
+
+    const reasonMap = {
+      won: 'Negócio ganho',
+      no_contact: 'Sem contato',
+      disqualified: 'Lead desqualificado',
+    };
+    const reason = reasonMap[value];
+    await handleResult(value, reason);
+  }, [handleResult]);
+
+  const handleConfirmLoss = useCallback(async () => {
+    setLossSubmitted(true);
+    if (!lossReason) {
+      return;
+    }
+    const reasonLabel = LOSS_REASON_HELPERS[lossReason] ?? lossReason;
+    const finalReason = lossNotes ? `${reasonLabel} — ${lossNotes}` : reasonLabel;
+    try {
+      await handleResult('lost', finalReason);
+      setLossDialogOpen(false);
+      resetLossState();
+    } catch {
+      // feedback handled upstream
+    }
+  }, [handleResult, lossReason, lossNotes, resetLossState]);
+
+  const handleCloseLossDialog = useCallback((nextOpen) => {
+    setLossDialogOpen(nextOpen);
+    if (!nextOpen) {
+      resetLossState();
+    }
+  }, [resetLossState]);
+
+  const handlePhoneAction = useCallback((action) => {
+    if (!rawPhone) {
+      toast.info('Nenhum telefone disponível para este lead.');
+      return;
+    }
+    const digits = String(rawPhone).replace(/\D/g, '');
+    const hasWindow = typeof window !== 'undefined';
+    const hasClipboard = typeof navigator !== 'undefined' && navigator.clipboard;
+
+    switch (action) {
+      case 'call':
+        if (hasWindow) {
+          window.open(`tel:${digits}`, '_self');
+        } else {
+          toast.info(`Ligue para ${rawPhone}.`);
+        }
+        break;
+      case 'whatsapp':
+        if (hasWindow) {
+          window.open(`https://wa.me/${digits}`, '_blank', 'noopener');
+        } else {
+          toast.info(`Abra o WhatsApp e contate ${rawPhone}.`);
+        }
+        break;
+      case 'copy':
+        if (hasClipboard) {
+          navigator.clipboard
+            .writeText(rawPhone)
+            .then(() => toast.success('Telefone copiado.'))
+            .catch(() => toast.error('Não foi possível concluir. Tente novamente.'));
+        } else {
+          toast.info(`Copie manualmente: ${rawPhone}`);
+        }
+        break;
+      default:
+        break;
+    }
+  }, [rawPhone]);
+
+  const handleCopyDocument = useCallback(() => {
+    if (!document || document === '—') {
+      toast.info('Nenhum documento disponível para copiar.');
+      return;
+    }
+    const hasClipboard = typeof navigator !== 'undefined' && navigator.clipboard;
+    if (hasClipboard) {
+      navigator.clipboard
+        .writeText(document)
+        .then(() => toast.success('Documento copiado.'))
+        .catch(() => toast.error('Não foi possível concluir. Tente novamente.'));
+    } else {
+      toast.info(`Copie manualmente: ${document}`);
+    }
+  }, [document]);
+
   if (!ticket) {
     return (
-      <div className="flex h-24 items-center justify-center rounded-[26px] bg-slate-950/25 text-sm text-slate-400 shadow-inner shadow-slate-950/40 ring-1 ring-white/5 backdrop-blur">
+      <div className="flex h-24 items-center justify-center rounded-2xl border border-white/8 bg-slate-950/40 text-sm text-slate-400 shadow-inner shadow-slate-950/40 backdrop-blur">
         Selecione um ticket para visualizar a conversa.
       </div>
     );
   }
 
-  const name = ticket.contact?.name ?? ticket.subject ?? 'Contato sem nome';
-  const phone = formatPhoneNumber(ticket.contact?.phone || ticket?.metadata?.contactPhone);
-  const document = ticket.contact?.document ?? '—';
-  const remoteJid = ticket?.metadata?.whatsapp?.remoteJid || ticket?.metadata?.remoteJid || null;
-
   return (
-    <div className="flex flex-col gap-4 rounded-[26px] bg-slate-950/25 px-6 py-5 text-slate-100 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.9)] ring-1 ring-white/5 backdrop-blur">
-      <div className="flex flex-col gap-1">
-        <div className="flex flex-wrap items-center gap-2 text-lg font-semibold text-slate-100">
-          <span>{name}</span>
-          <StatusBadge status={ticket.status} />
-          <PipelineStepTag step={ticket.pipelineStep ?? ticket.metadata?.pipelineStep} />
-          <SlaBadge window={ticket.window} />
+    <div
+      className={cn(
+        'space-y-4 rounded-2xl border border-white/12 bg-slate-950/85 p-4 shadow-[0_4px_24px_rgba(15,23,42,0.45)] backdrop-blur transition-opacity duration-150',
+        isFadeIn ? 'opacity-100' : 'opacity-0',
+      )}
+    >
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-[18px] font-semibold tracking-[0.2px] text-white">
+            {title}
+          </h3>
+          <Chip tone={statusInfo.tone}>{statusInfo.label}</Chip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Chip tone={expirationInfo.tone} className="cursor-default select-none">
+                {expirationInfo.label}
+              </Chip>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" align="start">
+              <p className="max-w-[220px] text-xs text-white/80">{slaTooltip}</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
-        <div className="text-xs text-slate-400">
-          Lead #{ticket.lead?.id ?? '—'} · Valor potencial {ticket.lead?.value ? `R$ ${ticket.lead.value}` : '—'} · Probabilidade {ticket.lead?.probability ?? '—'}%
-        </div>
-      </div>
+        <p className="text-[13px] font-medium text-white/70">{subtitle}</p>
+      </header>
 
-      <div className="flex flex-wrap items-center gap-2">
-        {typingAgents.length > 0 ? (
-          <div className="flex items-center gap-2 rounded-full bg-slate-900/40 px-3 py-1 text-xs text-slate-200 ring-1 ring-white/5">
-            <div className="flex -space-x-2">
-              {typingAgents.slice(0, 3).map((agent) => (
-                <Avatar key={agent.userId} className="h-6 w-6 border border-slate-900/40">
-                  <AvatarFallback>{buildInitials(agent.userName, 'AG')}</AvatarFallback>
-                </Avatar>
-              ))}
-            </div>
-            <span>{typingAgents[0].userName ?? 'Agente'} digitando…</span>
-          </div>
-        ) : null}
-        <Button size="sm" variant="secondary" className="bg-slate-900/50 text-slate-100 hover:bg-slate-900/40" onClick={() => onAssign?.(ticket)}>
-          Atribuir
-        </Button>
-        <Button size="sm" variant="outline" className="border-transparent bg-slate-900/40 text-slate-200 hover:bg-slate-900/30" onClick={() => onGenerateProposal?.(ticket)}>
+      <section className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          size="lg"
+          onClick={() => onGenerateProposal?.(ticket)}
+          className="min-h-[44px] rounded-xl bg-sky-500 text-white hover:bg-sky-400 focus-visible:ring-sky-300 active:bg-sky-600"
+        >
           Gerar proposta
         </Button>
-        <Button size="sm" variant="default" className="bg-emerald-600 hover:bg-emerald-500" onClick={() => onMarkWon?.(ticket)}>
-          Ganho
+        <Button
+          type="button"
+          size="lg"
+          variant="outline"
+          onClick={() => onAssign?.(ticket)}
+          className="min-h-[44px] rounded-xl border-white/20 bg-white/5 text-white/80 hover:bg-white/10"
+        >
+          Atribuir
         </Button>
-        <Button size="sm" variant="outline" className="border-rose-500/60 text-rose-200 hover:bg-rose-500/10" onClick={() => onMarkLost?.(ticket)}>
-          Perda
+        <Button
+          type="button"
+          size="lg"
+          variant="outline"
+          onClick={() => onScheduleFollowUp?.(ticket)}
+          className="min-h-[44px] rounded-xl border-white/20 bg-white/5 text-white/80 hover:bg-white/10"
+        >
+          Agendar follow-up
         </Button>
-      </div>
-      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
-        <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-200 ring-1 ring-white/5">
-          {phone}
-        </Badge>
-        <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-200 ring-1 ring-white/5">
-          Documento: {document}
-        </Badge>
-        {remoteJid ? (
-          <Badge variant="outline" className="border-transparent bg-slate-900/40 text-[11px] text-slate-300 ring-1 ring-white/5">
-            {remoteJid}
-          </Badge>
-        ) : null}
-      </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              size="lg"
+              aria-label="Registrar resultado"
+              className="min-h-[44px] rounded-xl bg-white/12 text-white hover:bg-white/16 focus-visible:ring-white/40"
+              disabled={isRegisteringResult}
+            >
+              <span className="mr-1">Registrar resultado</span>
+              <ChevronDown className="size-4" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-56">
+            <DropdownMenuRadioGroup value={resultSelection || undefined} onValueChange={handleResultChange}>
+              {RESULT_ITEMS.map((item) => (
+                <DropdownMenuRadioItem
+                  key={item.value}
+                  value={item.value}
+                  className="min-h-[44px]"
+                  disabled={isRegisteringResult}
+                >
+                  {item.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <TypingIndicator agents={typingAgents} />
+      </section>
+
+      <footer className="flex flex-wrap items-center gap-2 pt-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <MetadataBadge icon={Phone} aria-label="Telefone">
+              {phoneDisplay}
+            </MetadataBadge>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-52">
+            <DropdownMenuItem className="min-h-[44px]" onSelect={() => handlePhoneAction('call')}>
+              Ligar
+            </DropdownMenuItem>
+            <DropdownMenuItem className="min-h-[44px]" onSelect={() => handlePhoneAction('whatsapp')}>
+              Abrir WhatsApp
+            </DropdownMenuItem>
+            <DropdownMenuItem className="min-h-[44px]" onSelect={() => handlePhoneAction('copy')}>
+              Copiar
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <MetadataBadge
+          icon={IdCard}
+          aria-label="Copiar documento"
+          onClick={handleCopyDocument}
+        >
+          Doc: {document}
+        </MetadataBadge>
+      </footer>
+
+      <Dialog open={lossDialogOpen} onOpenChange={handleCloseLossDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Registrar perda</DialogTitle>
+            <DialogDescription>
+              Informe o motivo da perda para manter o funil atualizado.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="loss-reason">Motivo *</Label>
+              <Select value={lossReason} onValueChange={(value) => { setLossReason(value); setLossSubmitted(false); }}>
+                <SelectTrigger id="loss-reason" className="w-full min-h-[44px]">
+                  <SelectValue placeholder="Selecione" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOSS_REASONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {lossSubmitted && !lossReason ? (
+                <p className="text-xs text-rose-300">Selecione um motivo para continuar.</p>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="loss-notes">Observações (opcional)</Label>
+              <Textarea
+                id="loss-notes"
+                value={lossNotes}
+                onChange={(event) => setLossNotes(event.target.value)}
+                placeholder="Detalhe o motivo ou próximos passos."
+              />
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="outline" onClick={() => handleCloseLossDialog(false)} className="min-h-[44px]">
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirmLoss}
+              disabled={isRegisteringResult}
+              className="min-h-[44px]"
+            >
+              Registrar perda
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rebuild the conversation header card with updated layout, typography, chips, split button, and metadata menus aligned to the new design brief
- wire the conversation area to the unified result registration flow and expose follow-up scheduling alongside proposal generation
- consolidate result handling in the chat command center with new toast microcopy and loading states

## Testing
- pnpm --filter web exec eslint src/features/chat/components/ConversationArea/ConversationHeader.jsx src/features/chat/ChatCommandCenter.jsx src/features/chat/components/ConversationArea/ConversationArea.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e5631c678083328f6f0e5c81ac28f6