### PR TITLE
Improve lead inbox queue scroll and spacing

### DIFF
--- a/apps/web/src/features/leads/inbox/components/InboxList.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxList.jsx
@@ -15,12 +15,12 @@ export const InboxList = ({
 }) => {
   if (loading) {
     return (
-      <div className="space-y-3" aria-live="polite" aria-busy="true">
+      <div className="space-y-2.5" aria-live="polite" aria-busy="true">
         <span className="sr-only">Carregando leads…</span>
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`allocation-skeleton-${index}`}
-            className="space-y-4 rounded-3xl border border-white/6 bg-white/[0.03] p-5"
+            className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
           >
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-2">
@@ -33,7 +33,7 @@ export const InboxList = ({
               <div className="h-6 w-28 animate-pulse rounded-full bg-white/10" />
             </div>
 
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="grid gap-2.5 sm:grid-cols-3">
               {Array.from({ length: 3 }).map((_, detailIndex) => (
                 <div key={`allocation-detail-${detailIndex}`} className="space-y-2">
                   <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/10" />
@@ -42,7 +42,7 @@ export const InboxList = ({
               ))}
             </div>
 
-            <div className="grid gap-3 border-t border-white/5 pt-3 sm:grid-cols-2">
+            <div className="grid gap-2.5 border-t border-white/5 pt-3 sm:grid-cols-2">
               {Array.from({ length: 2 }).map((_, summaryIndex) => (
                 <div key={`allocation-summary-${summaryIndex}`} className="space-y-2">
                   <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/10" />
@@ -76,7 +76,7 @@ export const InboxList = ({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2.5">
       {filteredAllocations.map((allocation) => (
         <LeadAllocationCard
           key={allocation.allocationId}

--- a/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
@@ -53,26 +53,26 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
       onClick={() => onSelect?.(allocation)}
       onDoubleClick={() => (allocation && onDoubleOpen ? onDoubleOpen(allocation) : null)}
       className={cn(
-        'group flex w-full flex-col gap-4 rounded-3xl border border-white/6 bg-white/[0.02] p-5 text-left transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
+        'group flex w-full flex-col gap-3.5 rounded-2xl border border-white/10 bg-white/[0.02] p-4 text-left transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
         isActive
           ? 'border-sky-500/45 bg-sky-500/10 shadow-[0_18px_48px_rgba(14,116,144,0.24)] focus-visible:ring-sky-400'
           : 'hover:border-sky-500/25 hover:bg-white/[0.05] focus-visible:ring-sky-400/40'
       )}
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-2">
-          <p className="text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground/65">Lead</p>
-          <div className="space-y-1">
-            <h3 className="text-lg font-semibold leading-snug text-foreground group-hover:text-foreground/95">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-muted-foreground/65">Lead</p>
+          <div className="space-y-0.5">
+            <h3 className="text-base font-semibold leading-snug text-foreground group-hover:text-foreground/95">
               {allocation.fullName}
             </h3>
-            <p className="text-sm text-muted-foreground/75">{formatDocument(allocation.document)}</p>
+            <p className="text-[13px] text-muted-foreground/75">{formatDocument(allocation.document)}</p>
           </div>
         </div>
         <Badge
           variant="outline"
           className={cn(
-            'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+            'border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] transition-colors',
             statusTone
           )}
         >
@@ -80,29 +80,29 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
         </Badge>
       </div>
 
-      <div className="grid gap-3 text-sm text-muted-foreground/80 sm:grid-cols-3">
-        <div className="space-y-1.5">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Telefone</p>
+      <div className="grid gap-2.5 text-[13px] text-muted-foreground/80 sm:grid-cols-3">
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Telefone</p>
           <p className="font-medium text-foreground/90">{allocation.phone ?? '—'}</p>
         </div>
-        <div className="space-y-1.5">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Score</p>
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Score</p>
           <p className="font-medium text-foreground/90">{allocation.score ?? '—'}</p>
         </div>
-        <div className="space-y-1.5">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Registros</p>
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Registros</p>
           <p className="font-medium text-foreground/90">{resolveRegistrations(allocation.registrations)}</p>
         </div>
       </div>
 
-      <div className="grid gap-3 border-t border-white/5 pt-3 text-sm sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem bruta</p>
-          <p className="text-base font-semibold text-foreground/90">{formatCurrency(allocation.margin)}</p>
+      <div className="grid gap-2.5 border-t border-white/5 pt-3 text-[13px] sm:grid-cols-2">
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem bruta</p>
+          <p className="text-[15px] font-semibold text-foreground/90">{formatCurrency(allocation.margin)}</p>
         </div>
-        <div className="space-y-1.5">
-          <p className="text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem disponível</p>
-          <p className="text-base font-semibold text-foreground/90">
+        <div className="space-y-1">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem disponível</p>
+          <p className="text-[15px] font-semibold text-foreground/90">
             {formatCurrency(allocation.netMargin ?? allocation.margin)}
           </p>
         </div>

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -691,15 +691,15 @@ export const LeadInbox = ({
   }, [agreementId, campaign?.instanceId, campaignId, filters.status]);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6 xl:space-y-8">
       <InboxHeader
         stepLabel={stepLabel}
         campaign={campaign}
         onboarding={onboarding}
       />
 
-      <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)_360px]">
-        <section className="flex min-h-[520px] flex-col gap-5 rounded-3xl border border-white/5 bg-slate-950/60 p-5 shadow-[0_12px_38px_rgba(15,23,42,0.32)]">
+      <div className="grid gap-5 xl:grid-cols-[300px_minmax(0,1fr)_340px] xl:gap-6">
+        <section className="flex min-h-[520px] flex-col gap-4 rounded-2xl border border-white/5 bg-slate-950/60 p-4 shadow-[0_12px_32px_rgba(15,23,42,0.28)] xl:max-h-[calc(100vh-220px)] xl:overflow-hidden">
           <GlobalFiltersBar
             filters={filters}
             onUpdateFilters={handleUpdateFilters}
@@ -717,7 +717,7 @@ export const LeadInbox = ({
 
           <div className="h-px bg-white/5" />
 
-          <div className="flex-1 overflow-y-auto pr-1">
+          <div className="flex-1 overflow-y-auto pr-1 xl:pr-2">
             <InboxList
               allocations={allocations}
               filteredAllocations={filteredAllocations}


### PR DESCRIPTION
## Summary
- cap the lead inbox queue panel height and enable an internal scroll region on wide layouts
- tighten spacing and padding in the lead list skeletons and cards to show more information per viewport

## Testing
- pnpm lint *(fails: existing lint error in apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e56fd48690833286373898e72e7a88