### PR TITLE
Refine inbox lead hierarchy and contrast

### DIFF
--- a/apps/web/src/features/leads/inbox/components/InboxActions.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxActions.jsx
@@ -36,28 +36,28 @@ export const InboxActions = ({
 
   return (
     <div className="space-y-4">
-      <Card className="rounded-3xl border-white/5 bg-slate-950/60 shadow-sm">
+      <Card className="rounded-3xl border-white/15 bg-white/[0.08] shadow-[0_18px_40px_rgba(5,12,30,0.45)]">
         <CardHeader className="space-y-2 pb-3">
-          <CardTitle className="text-sm font-semibold text-foreground/90">Sincronização inteligente</CardTitle>
-          <CardDescription className="text-xs text-muted-foreground">
+          <CardTitle className="text-sm font-semibold text-white/85">Sincronização inteligente</CardTitle>
+          <CardDescription className="text-xs text-white/70">
             Leads chegam automaticamente após cada mensagem recebida. Você pode forçar uma atualização a qualquer momento.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4 text-xs">
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-muted-foreground">
-            <div className="flex items-center gap-2 text-left text-sm text-foreground/90">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/15 bg-white/[0.08] px-4 py-3 text-white/75 shadow-[0_14px_32px_rgba(5,12,28,0.35)]">
+            <div className="flex items-center gap-2 text-left text-sm text-white/90">
               {loading ? (
-                <Loader2 className="h-4 w-4 animate-spin text-foreground/80" />
+                <Loader2 className="h-4 w-4 animate-spin text-white/75" />
               ) : (
-                <RefreshCcw className="h-4 w-4 text-foreground/70" />
+                <RefreshCcw className="h-4 w-4 text-white/70" />
               )}
               <div>
-                <p className="font-medium leading-tight text-foreground">{primaryRefreshLabel}</p>
-                <p className="text-xs text-muted-foreground/80">{secondaryRefreshLabel}</p>
+                <p className="font-medium leading-tight text-white/90">{primaryRefreshLabel}</p>
+                <p className="text-xs text-white/70">{secondaryRefreshLabel}</p>
               </div>
             </div>
             {lastUpdatedLabel ? (
-              <span className="text-[11px] font-medium text-muted-foreground/80">{lastUpdatedLabel}</span>
+              <span className="text-[11px] font-medium text-white/70">{lastUpdatedLabel}</span>
             ) : null}
           </div>
 
@@ -69,7 +69,7 @@ export const InboxActions = ({
                   size="sm"
                   onClick={onRefresh}
                   disabled={loading}
-                  className={cn('gap-2 text-sm font-medium text-foreground/90')}
+                  className={cn('gap-2 text-sm font-medium text-white/90 border-white/20 bg-white/[0.04] hover:border-white/30 hover:bg-white/[0.1]')}
                 >
                   {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
                   {loading ? 'Sincronizando…' : 'Atualizar agora'}
@@ -81,7 +81,7 @@ export const InboxActions = ({
               variant="ghost"
               size="sm"
               onClick={onExport}
-              className="gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+              className="gap-2 text-sm font-medium text-white/75 hover:text-white"
             >
               <Download className="h-4 w-4" /> Exportar CSV
             </Button>
@@ -92,7 +92,7 @@ export const InboxActions = ({
       {rateLimitInfo.show ? (
         <NoticeBanner
           variant="warning"
-          className="rounded-2xl border-white/10 bg-white/5 text-sm text-foreground/90"
+          className="rounded-2xl border-white/12 bg-white/[0.08] text-sm text-white/85"
         >
           Muitas requisições recentes. Aguarde {rateLimitInfo.retryAfter ?? rateLimitInfo.resetSeconds ?? 0}s para evitar
           bloqueios.

--- a/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxHeader.jsx
@@ -22,32 +22,32 @@ export const InboxHeader = ({ stepLabel, campaign, onboarding }) => {
   ];
 
   return (
-    <header className="space-y-6">
-      <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground/70">
+    <header className="rounded-[32px] border border-white/12 bg-[#0b172b] p-6 shadow-[0_20px_46px_rgba(3,8,22,0.5)] ring-1 ring-white/10">
+      <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.24em] text-white/70">
         {stepLabel ? (
           <Badge
             variant="outline"
-            className="border-border/60 bg-transparent px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-muted-foreground/80"
+            className="border-white/40 bg-white/[0.08] px-3 py-1 text-[11px] font-medium uppercase tracking-[0.28em] text-white/80"
           >
             {stepLabel}
           </Badge>
         ) : null}
-        <span className="text-muted-foreground/70">Fluxo concluído</span>
+        <span className="text-white/70">Fluxo concluído</span>
       </div>
 
-      <Breadcrumb className="text-[11px] font-medium text-muted-foreground/70">
+      <Breadcrumb className="mt-5 text-[11px] font-medium text-white/70">
         <BreadcrumbList>
           {breadcrumbItems.map((item, index) => (
             <BreadcrumbItem key={item.label}>
               {item.current ? (
-                <BreadcrumbPage className="flex items-center gap-1.5 text-sm font-semibold text-foreground/85">
-                  {item.icon ? <item.icon className="h-3.5 w-3.5 text-muted-foreground/65" aria-hidden /> : null}
+                <BreadcrumbPage className="flex items-center gap-1.5 text-sm font-semibold text-white/85">
+                  {item.icon ? <item.icon className="h-3.5 w-3.5 text-white/65" aria-hidden /> : null}
                   <span>{item.label}</span>
                 </BreadcrumbPage>
               ) : (
                 <BreadcrumbLink
                   href={item.href}
-                  className="text-[11px] font-medium text-muted-foreground/70 hover:text-foreground/80"
+                  className="text-[11px] font-medium text-white/70 hover:text-white/90"
                 >
                   {item.label}
                 </BreadcrumbLink>
@@ -58,30 +58,30 @@ export const InboxHeader = ({ stepLabel, campaign, onboarding }) => {
         </BreadcrumbList>
       </Breadcrumb>
 
-      <div className="flex flex-wrap items-start justify-between gap-6">
+      <div className="mt-6 flex flex-wrap items-start justify-between gap-6">
         <div className="space-y-2">
-          <h1 className="text-base font-bold text-foreground">Inbox de Leads</h1>
-          <p className="text-sm font-semibold text-muted-foreground/80">
+          <h1 className="text-xl font-semibold text-white/95">Inbox de Leads</h1>
+          <p className="text-sm font-semibold text-white/75">
             Organize e priorize as conversas do seu time em um só lugar.
           </p>
-          <p className="max-w-xl text-[13px] text-muted-foreground/80">
+          <p className="max-w-xl text-[13px] text-white/70">
             Respostas rápidas mantêm a confiança do lead. Acompanhe métricas e prossiga para {nextStage.toLowerCase()} quando estiver tudo pronto.
           </p>
         </div>
 
-        <div className="flex flex-col items-end gap-1 rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-right">
-          <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground/70">Status atual</p>
+        <div className="flex flex-col items-end gap-1 rounded-2xl border border-white/15 bg-white/[0.08] px-5 py-4 text-right shadow-[0_12px_32px_rgba(3,9,24,0.4)]">
+          <p className="text-[11px] font-medium uppercase tracking-[0.24em] text-white/70">Status atual</p>
           <p className="text-base font-semibold text-emerald-300">
             {hasLeadCount ? `${leadCount} leads ativos` : 'Monitorando leads'}
           </p>
-          <p className="text-[13px] text-muted-foreground/80">Próximo passo: {nextStage}</p>
+          <p className="text-[13px] text-white/70">Próximo passo: {nextStage}</p>
         </div>
       </div>
 
       {campaignName ? (
-        <div className="flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground/80">
-          <span className="text-sm font-semibold text-muted-foreground/90">Campanha ativa</span>
-          <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-[11px] font-medium text-muted-foreground/80">
+        <div className="mt-6 flex flex-wrap items-center gap-2 text-[13px] text-white/75">
+          <span className="text-sm font-semibold text-white/80">Campanha ativa</span>
+          <span className="rounded-full border border-white/15 bg-white/[0.08] px-3 py-1 text-[11px] font-medium text-white/70">
             {campaignName}
           </span>
         </div>

--- a/apps/web/src/features/leads/inbox/components/InboxList.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxList.jsx
@@ -15,38 +15,38 @@ export const InboxList = ({
 }) => {
   if (loading) {
     return (
-      <div className="space-y-2.5" aria-live="polite" aria-busy="true">
+      <div className="space-y-3" aria-live="polite" aria-busy="true">
         <span className="sr-only">Carregando leads…</span>
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`allocation-skeleton-${index}`}
-            className="space-y-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+            className="space-y-4 rounded-[24px] border border-white/12 bg-[#101d33] p-5 shadow-[0_18px_44px_rgba(3,9,24,0.45)]"
           >
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-2">
-                <div className="h-2.5 w-16 animate-pulse rounded-full bg-white/10" />
+                <div className="h-2.5 w-16 animate-pulse rounded-full bg-white/12" />
                 <div className="space-y-2">
-                  <div className="h-4 w-40 animate-pulse rounded-full bg-white/10" />
-                  <div className="h-3 w-24 animate-pulse rounded-full bg-white/10" />
+                  <div className="h-4 w-40 animate-pulse rounded-full bg-white/12" />
+                  <div className="h-3 w-24 animate-pulse rounded-full bg-white/12" />
                 </div>
               </div>
-              <div className="h-6 w-28 animate-pulse rounded-full bg-white/10" />
+              <div className="h-6 w-28 animate-pulse rounded-full bg-white/12" />
             </div>
 
-            <div className="grid gap-2.5 sm:grid-cols-3">
+            <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.04] p-3 sm:grid-cols-3">
               {Array.from({ length: 3 }).map((_, detailIndex) => (
                 <div key={`allocation-detail-${detailIndex}`} className="space-y-2">
-                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/10" />
-                  <div className="h-3.5 w-28 animate-pulse rounded-full bg-white/10" />
+                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/12" />
+                  <div className="h-3.5 w-28 animate-pulse rounded-full bg-white/12" />
                 </div>
               ))}
             </div>
 
-            <div className="grid gap-2.5 border-t border-white/5 pt-3 sm:grid-cols-2">
+            <div className="grid gap-3 border-t border-white/10 pt-4 sm:grid-cols-2">
               {Array.from({ length: 2 }).map((_, summaryIndex) => (
                 <div key={`allocation-summary-${summaryIndex}`} className="space-y-2">
-                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/10" />
-                  <div className="h-4 w-32 animate-pulse rounded-full bg-white/10" />
+                  <div className="h-2.5 w-24 animate-pulse rounded-full bg-white/12" />
+                  <div className="h-4 w-32 animate-pulse rounded-full bg-white/12" />
                 </div>
               ))}
             </div>
@@ -69,14 +69,14 @@ export const InboxList = ({
 
   if (filteredAllocations.length === 0) {
     return (
-      <div className="rounded-lg border border-dashed border-white/10 bg-white/5 p-6 text-center text-sm text-muted-foreground">
+      <div className="rounded-[24px] border border-dashed border-white/12 bg-[#101d33] p-6 text-center text-sm text-white/75 shadow-[0_18px_44px_rgba(3,9,24,0.45)]">
         Nenhum lead com o filtro selecionado.
       </div>
     );
   }
 
   return (
-    <div className="space-y-2.5">
+    <div className="space-y-3">
       {filteredAllocations.map((allocation) => (
         <LeadAllocationCard
           key={allocation.allocationId}

--- a/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
@@ -9,10 +9,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/[0.04] text-muted-foreground/85',
-  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
-  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
-  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
+  allocated: 'border-white/20 bg-white/[0.08] text-white/80',
+  contacted: 'border-sky-400/40 bg-sky-500/20 text-sky-100',
+  won: 'border-emerald-400/45 bg-emerald-400/20 text-emerald-100',
+  lost: 'border-rose-500/50 bg-rose-500/18 text-rose-100',
 };
 
 const formatCurrency = (value) => {
@@ -53,26 +53,26 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
       onClick={() => onSelect?.(allocation)}
       onDoubleClick={() => (allocation && onDoubleOpen ? onDoubleOpen(allocation) : null)}
       className={cn(
-        'group flex w-full flex-col gap-3.5 rounded-2xl border border-white/10 bg-white/[0.02] p-4 text-left transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950',
+        'group flex w-full flex-col gap-4 rounded-[24px] border border-white/12 bg-[#101d33] p-5 text-left shadow-[0_18px_44px_rgba(3,9,24,0.45)] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#070f1f] hover:border-white/20 hover:shadow-[0_26px_54px_rgba(5,12,30,0.55)]',
         isActive
-          ? 'border-sky-500/45 bg-sky-500/10 shadow-[0_18px_48px_rgba(14,116,144,0.24)] focus-visible:ring-sky-400'
-          : 'hover:border-sky-500/25 hover:bg-white/[0.05] focus-visible:ring-sky-400/40'
+          ? 'border-sky-400/60 bg-sky-500/20 shadow-[0_30px_70px_rgba(14,116,144,0.35)] focus-visible:ring-sky-300'
+          : 'hover:bg-[#13223d]'
       )}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1.5">
-          <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-muted-foreground/65">Lead</p>
+          <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-white/65">Lead</p>
           <div className="space-y-0.5">
-            <h3 className="text-base font-semibold leading-snug text-foreground group-hover:text-foreground/95">
+            <h3 className="text-base font-semibold leading-snug text-white/95 group-hover:text-white">
               {allocation.fullName}
             </h3>
-            <p className="text-[13px] text-muted-foreground/75">{formatDocument(allocation.document)}</p>
+            <p className="text-[13px] text-white/75">{formatDocument(allocation.document)}</p>
           </div>
         </div>
         <Badge
           variant="outline"
           className={cn(
-            'border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] transition-colors',
+            'border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] text-white/80 transition-colors',
             statusTone
           )}
         >
@@ -80,29 +80,29 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
         </Badge>
       </div>
 
-      <div className="grid gap-2.5 text-[13px] text-muted-foreground/80 sm:grid-cols-3">
+      <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.04] p-3 text-[13px] text-white/80 sm:grid-cols-3">
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Telefone</p>
-          <p className="font-medium text-foreground/90">{allocation.phone ?? '—'}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Telefone</p>
+          <p className="font-medium text-white/90">{allocation.phone ?? '—'}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Score</p>
-          <p className="font-medium text-foreground/90">{allocation.score ?? '—'}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Score</p>
+          <p className="font-medium text-white/90">{allocation.score ?? '—'}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Registros</p>
-          <p className="font-medium text-foreground/90">{resolveRegistrations(allocation.registrations)}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Registros</p>
+          <p className="font-medium text-white/90">{resolveRegistrations(allocation.registrations)}</p>
         </div>
       </div>
 
-      <div className="grid gap-2.5 border-t border-white/5 pt-3 text-[13px] sm:grid-cols-2">
+      <div className="grid gap-3 border-t border-white/10 pt-4 text-[13px] sm:grid-cols-2">
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem bruta</p>
-          <p className="text-[15px] font-semibold text-foreground/90">{formatCurrency(allocation.margin)}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Margem bruta</p>
+          <p className="text-[15px] font-semibold text-white/92">{formatCurrency(allocation.margin)}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground/60">Margem disponível</p>
-          <p className="text-[15px] font-semibold text-foreground/90">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Margem disponível</p>
+          <p className="text-[15px] font-semibold text-white/92">
             {formatCurrency(allocation.netMargin ?? allocation.margin)}
           </p>
         </div>

--- a/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
@@ -19,10 +19,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/[0.05] text-muted-foreground/85',
-  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
-  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
-  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
+  allocated: 'border-white/20 bg-white/[0.08] text-white/80',
+  contacted: 'border-sky-400/40 bg-sky-500/20 text-sky-100',
+  won: 'border-emerald-400/45 bg-emerald-400/20 text-emerald-100',
+  lost: 'border-rose-500/50 bg-rose-500/18 text-rose-100',
 };
 
 const ensureDate = (value) => {
@@ -191,19 +191,19 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
     ]) ?? allocation?.notes ?? null;
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col rounded-3xl border border-white/5 bg-slate-950/70 shadow-[0_8px_32px_rgba(15,23,42,0.32)]">
-      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/5 px-6 py-4">
+    <div className="flex h-full min-h-[520px] flex-col rounded-[32px] border border-white/12 bg-[#111f38] shadow-[0_26px_60px_rgba(3,8,23,0.55)] ring-1 ring-white/10">
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/12 bg-white/[0.04] px-6 py-4 shadow-[0_16px_30px_rgba(4,9,24,0.35)]">
         <div className="space-y-2">
-          <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-muted-foreground/70">Timeline</p>
+          <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-white/70">Timeline</p>
           <div className="flex flex-wrap items-center gap-3">
-            <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            <h2 className="text-lg font-semibold tracking-tight text-white/95">
               {allocation ? allocation.fullName : 'Selecione um lead'}
             </h2>
             {allocation ? (
               <Badge
                 variant="outline"
                 className={cn(
-                  'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+                  'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] text-white/80 transition-colors',
                   statusTone
                 )}
               >
@@ -212,12 +212,12 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
             ) : null}
           </div>
           {lastMessagePreview ? (
-            <p className="max-w-xl text-sm text-muted-foreground/90 line-clamp-2">{lastMessagePreview}</p>
+            <p className="max-w-xl text-sm text-white/80 line-clamp-2">{lastMessagePreview}</p>
           ) : null}
         </div>
         <Button
           size="sm"
-          className="gap-2 rounded-full bg-emerald-500/90 px-4 py-2 text-sm font-medium text-emerald-950 shadow-[0_8px_24px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
+          className="gap-2 rounded-full bg-emerald-500 px-4 py-2 text-sm font-medium text-emerald-950 shadow-[0_12px_26px_rgba(16,185,129,0.45)] transition hover:bg-emerald-400"
           onClick={() => (allocation && onOpenWhatsApp ? onOpenWhatsApp(allocation) : null)}
           disabled={!allocation?.phone || !onOpenWhatsApp}
         >
@@ -235,8 +235,8 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
           <div className="space-y-4">
             {[1, 2, 3].map((item) => (
               <div key={item} className="space-y-2">
-                <div className="h-3 w-24 animate-pulse rounded-full bg-white/10" />
-                <div className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+                <div className="h-3 w-24 animate-pulse rounded-full bg-white/12" />
+                <div className="h-4 w-full animate-pulse rounded-full bg-white/12" />
               </div>
             ))}
           </div>
@@ -244,8 +244,8 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground/80">
             <MessageSquareDashed className="h-10 w-10 text-muted-foreground/60" />
             <div className="space-y-1">
-              <p className="text-sm font-medium text-foreground/80">Selecione um lead para iniciar o foco</p>
-              <p className="text-xs text-muted-foreground/70">
+              <p className="text-sm font-medium text-white/85">Selecione um lead para iniciar o foco</p>
+              <p className="text-xs text-white/70">
                 A conversa aparece aqui com histórico e contexto assim que você escolhe um lead na lista.
               </p>
             </div>
@@ -254,8 +254,8 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
           <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground/80">
             <CalendarClock className="h-10 w-10 text-muted-foreground/60" />
             <div className="space-y-1">
-              <p className="text-sm font-medium text-foreground/80">Nenhum evento registrado ainda</p>
-              <p className="text-xs text-muted-foreground/70">
+              <p className="text-sm font-medium text-white/85">Nenhum evento registrado ainda</p>
+              <p className="text-xs text-white/70">
                 Assim que o lead interagir pelo WhatsApp, registramos automaticamente os marcos aqui.
               </p>
             </div>
@@ -267,16 +267,16 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
               return (
                 <li key={`${event.key}-${event.date?.getTime?.() ?? Math.random()}`} className="space-y-1.5">
                   <div className="flex items-center gap-3">
-                    <div className="flex size-9 items-center justify-center rounded-full border border-white/10 bg-white/5">
-                      <Icon className="h-4 w-4 text-muted-foreground/70" />
+                    <div className="flex size-9 items-center justify-center rounded-full border border-white/15 bg-white/[0.08] shadow-[0_10px_22px_rgba(4,10,26,0.35)]">
+                      <Icon className="h-4 w-4 text-white/75" />
                     </div>
                     <div>
-                      <p className="text-sm font-medium text-foreground/90">{event.label}</p>
-                      <p className="text-xs text-muted-foreground/70">{formatDateTime(event.date)}</p>
+                      <p className="text-sm font-medium text-white/90">{event.label}</p>
+                      <p className="text-xs text-white/70">{formatDateTime(event.date)}</p>
                     </div>
                   </div>
                   {event.description ? (
-                    <p className="ml-12 text-sm text-muted-foreground/90">{event.description}</p>
+                    <p className="ml-12 text-sm text-white/80">{event.description}</p>
                   ) : null}
                 </li>
               );

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -691,37 +691,38 @@ export const LeadInbox = ({
   }, [agreementId, campaign?.instanceId, campaignId, filters.status]);
 
   return (
-    <div className="space-y-6 xl:space-y-8">
+    <div className="space-y-8 xl:space-y-10">
       <InboxHeader
         stepLabel={stepLabel}
         campaign={campaign}
         onboarding={onboarding}
       />
 
-      <div className="grid gap-5 xl:grid-cols-[300px_minmax(0,1fr)_340px] xl:gap-6">
-        <section className="flex min-h-[520px] flex-col gap-4 rounded-2xl border border-white/5 bg-slate-950/60 p-4 shadow-[0_12px_32px_rgba(15,23,42,0.28)] xl:max-h-[calc(100vh-220px)] xl:overflow-hidden">
-          <GlobalFiltersBar
-            filters={filters}
-            onUpdateFilters={handleUpdateFilters}
-            onResetFilters={handleResetFilters}
-            queueOptions={queueOptions}
-            windowOptions={TIME_WINDOW_OPTIONS}
-            savedViews={savedViewsWithCount}
-            activeViewId={activeViewId}
-            onSelectSavedView={handleSelectSavedView}
-            onSaveCurrentView={handleSaveCurrentView}
-            onDeleteSavedView={handleDeleteSavedView}
-            canSaveView={canSaveCurrentView}
-            viewLimit={SAVED_VIEWS_LIMIT}
-          />
+      <div className="grid gap-6 xl:grid-cols-[300px_minmax(0,1fr)_340px] xl:gap-7">
+        <div className="relative">
+          <section className="flex min-h-[520px] flex-col gap-5 rounded-[28px] border border-white/10 bg-[#0c192e] p-5 shadow-[0_24px_52px_rgba(4,10,24,0.55)] ring-1 ring-white/10 xl:max-h-[calc(100vh-220px)] xl:overflow-hidden">
+            <GlobalFiltersBar
+              filters={filters}
+              onUpdateFilters={handleUpdateFilters}
+              onResetFilters={handleResetFilters}
+              queueOptions={queueOptions}
+              windowOptions={TIME_WINDOW_OPTIONS}
+              savedViews={savedViewsWithCount}
+              activeViewId={activeViewId}
+              onSelectSavedView={handleSelectSavedView}
+              onSaveCurrentView={handleSaveCurrentView}
+              onDeleteSavedView={handleDeleteSavedView}
+              canSaveView={canSaveCurrentView}
+              viewLimit={SAVED_VIEWS_LIMIT}
+            />
 
-          <div className="h-px bg-white/5" />
+            <div className="h-px bg-white/12" />
 
-          <div className="flex-1 overflow-y-auto pr-1 xl:pr-2">
-            <InboxList
-              allocations={allocations}
-              filteredAllocations={filteredAllocations}
-              loading={loading}
+            <div className="flex-1 overflow-y-auto pr-1 xl:pr-2">
+              <InboxList
+                allocations={allocations}
+                filteredAllocations={filteredAllocations}
+                loading={loading}
               selectedAgreement={selectedAgreement}
               campaign={campaign}
               onBackToWhatsApp={onBackToWhatsApp}
@@ -732,74 +733,85 @@ export const LeadInbox = ({
             />
           </div>
 
-          <div className="space-y-3 text-sm">
-            {!realtimeConnected && !connectionError ? (
-              <NoticeBanner
-                variant="info"
-                className="rounded-2xl border-white/10 bg-white/5 text-foreground/90"
-              >
-                Conectando ao tempo real para receber novos leads automaticamente…
-              </NoticeBanner>
-            ) : null}
+            <div className="space-y-3 text-sm">
+              {!realtimeConnected && !connectionError ? (
+                <NoticeBanner
+                  variant="info"
+                  className="rounded-2xl border-white/12 bg-white/[0.07] text-white/85"
+                >
+                  Conectando ao tempo real para receber novos leads automaticamente…
+                </NoticeBanner>
+              ) : null}
 
-            {connectionError ? (
-              <NoticeBanner
-                variant="warning"
-                icon={<AlertCircle className="h-4 w-4" />}
-                className="rounded-2xl border-white/10 bg-white/5 text-foreground/90"
-              >
-                Tempo real indisponível: {connectionError}. Continuamos monitorando via atualização automática.
-              </NoticeBanner>
-            ) : null}
+              {connectionError ? (
+                <NoticeBanner
+                  variant="warning"
+                  icon={<AlertCircle className="h-4 w-4" />}
+                  className="rounded-2xl border-white/12 bg-white/[0.07] text-white/85"
+                >
+                  Tempo real indisponível: {connectionError}. Continuamos monitorando via atualização automática.
+                </NoticeBanner>
+              ) : null}
 
-            {error ? (
-              <NoticeBanner
-                variant="danger"
-                icon={<AlertCircle className="h-4 w-4" />}
-                className="rounded-2xl border-white/10 bg-rose-500/10 text-rose-100"
-              >
-                {error}
-              </NoticeBanner>
-            ) : null}
+              {error ? (
+                <NoticeBanner
+                  variant="danger"
+                  icon={<AlertCircle className="h-4 w-4" />}
+                  className="rounded-2xl border-white/15 bg-rose-500/15 text-rose-50"
+                >
+                  {error}
+                </NoticeBanner>
+              ) : null}
 
-            {!error && warningMessage ? (
-              <NoticeBanner
-                variant="warning"
-                icon={<AlertCircle className="h-4 w-4" />}
-                className="rounded-2xl border-white/10 bg-white/5 text-foreground/90"
-              >
-                {warningMessage}
-              </NoticeBanner>
-            ) : null}
+              {!error && warningMessage ? (
+                <NoticeBanner
+                  variant="warning"
+                  icon={<AlertCircle className="h-4 w-4" />}
+                  className="rounded-2xl border-white/12 bg-white/[0.07] text-white/85"
+                >
+                  {warningMessage}
+                </NoticeBanner>
+              ) : null}
+            </div>
+          </section>
+
+          <div className="pointer-events-none absolute inset-y-6 -right-4 hidden xl:block">
+            <span className="block h-full w-px rounded-full bg-white/12 shadow-[1px_0_18px_rgba(5,10,26,0.55)]" />
           </div>
-        </section>
+        </div>
 
-        <LeadConversationPanel
-          allocation={activeAllocation}
-          onOpenWhatsApp={handleOpenWhatsApp}
-          isLoading={loading}
-          isSwitching={leadPanelSwitching}
-        />
+        <div className="relative">
+          <LeadConversationPanel
+            allocation={activeAllocation}
+            onOpenWhatsApp={handleOpenWhatsApp}
+            isLoading={loading}
+            isSwitching={leadPanelSwitching}
+          />
 
-        <aside className="flex flex-col gap-5">
-          <Card className="rounded-3xl border-white/5 bg-slate-950/60 shadow-[0_12px_36px_rgba(15,23,42,0.32)]">
+          <div className="pointer-events-none absolute inset-y-6 -right-4 hidden xl:block">
+            <span className="block h-full w-px rounded-full bg-white/10 shadow-[1px_0_20px_rgba(4,9,24,0.5)]" />
+          </div>
+        </div>
+
+        <aside className="flex min-h-[520px] flex-col gap-4 rounded-[28px] border border-white/12 bg-[#162946] p-5 shadow-[0_24px_52px_rgba(6,14,38,0.55)] ring-1 ring-white/10">
+          <Card className="rounded-3xl border-white/15 bg-white/[0.08] shadow-[0_18px_40px_rgba(5,12,30,0.45)]">
             <CardHeader className="space-y-2 pb-2">
-              <CardTitle className="text-sm font-semibold uppercase tracking-[0.24em] text-muted-foreground/70">
+              <CardTitle className="text-sm font-semibold uppercase tracking-[0.24em] text-white/80">
                 Resumo
               </CardTitle>
-              <CardDescription className="text-xs text-muted-foreground/80">
+              <CardDescription className="text-xs text-white/70">
                 Distribuição dos leads recebidos via WhatsApp conectado.
               </CardDescription>
             </CardHeader>
             <CardContent>
               <dl className="grid grid-cols-2 gap-4">
                 {statusMetrics.map(({ key, label, accent, icon }) => (
-                  <div key={key} className="space-y-1 rounded-2xl border border-white/5 bg-white/5 px-3 py-3">
-                    <dt className="flex items-center gap-2 text-xs font-medium text-muted-foreground/70">
+                  <div key={key} className="space-y-1 rounded-2xl border border-white/15 bg-white/[0.07] px-3 py-3 shadow-[0_14px_30px_rgba(5,12,28,0.35)]">
+                    <dt className="flex items-center gap-2 text-xs font-medium text-white/75">
                       {icon ? icon : null}
                       <span>{label}</span>
                     </dt>
-                    <dd className={cn('text-xl font-semibold text-foreground/90', accent ?? '')}>
+                    <dd className={cn('text-xl font-semibold text-white/90', accent ?? '')}>
                       {formatSummaryValue(summary[key])}
                     </dd>
                   </div>

--- a/apps/web/src/features/leads/inbox/components/LeadProfilePanel.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadProfilePanel.jsx
@@ -22,10 +22,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/10 bg-white/[0.05] text-muted-foreground/85',
-  contacted: 'border-slate-500/35 bg-slate-500/12 text-slate-100/90',
-  won: 'border-slate-200/40 bg-slate-200/10 text-slate-100',
-  lost: 'border-rose-500/45 bg-rose-500/12 text-rose-100',
+  allocated: 'border-white/20 bg-white/[0.08] text-white/80',
+  contacted: 'border-sky-400/40 bg-sky-500/20 text-sky-100',
+  won: 'border-emerald-400/45 bg-emerald-400/20 text-emerald-100',
+  lost: 'border-rose-500/50 bg-rose-500/18 text-rose-100',
 };
 
 const formatCurrency = (value) => {
@@ -99,23 +99,23 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
   return (
     <Card
       className={cn(
-        'rounded-3xl border-white/5 bg-slate-950/70 shadow-[0_6px_28px_rgba(15,23,42,0.38)] transition-opacity duration-150 ease-out',
+        'rounded-3xl border-white/15 bg-white/[0.08] shadow-[0_18px_40px_rgba(5,12,30,0.45)] transition-opacity duration-150 ease-out',
         isSwitching ? 'opacity-0' : 'opacity-100'
       )}
       aria-busy={showSkeleton}
     >
       <CardHeader className="space-y-3 pb-2">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm font-semibold tracking-[0.12em] text-foreground/90 uppercase">
+          <CardTitle className="text-sm font-semibold uppercase tracking-[0.12em] text-white/80">
             Informações do lead
           </CardTitle>
           {showSkeleton ? (
-            <div className="h-6 w-32 animate-pulse rounded-full bg-white/10" />
+            <div className="h-6 w-32 animate-pulse rounded-full bg-white/12" />
           ) : allocation ? (
             <Badge
               variant="outline"
               className={cn(
-                'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] transition-colors',
+                'border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.26em] text-white/80 transition-colors',
                 statusTone
               )}
             >
@@ -123,7 +123,7 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
             </Badge>
           ) : null}
         </div>
-        <p className="text-xs text-muted-foreground/70">
+        <p className="text-xs text-white/70">
           Dados essenciais sempre visíveis para agilizar o atendimento e garantir foco na conversa.
         </p>
       </CardHeader>
@@ -133,32 +133,32 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {Array.from({ length: 4 }).map((_, index) => (
                 <div key={`skeleton-info-${index}`} className="space-y-2">
-                  <div className="h-3 w-32 animate-pulse rounded-full bg-white/10" />
-                  <div className="h-4 w-full animate-pulse rounded-full bg-white/10" />
+                  <div className="h-3 w-32 animate-pulse rounded-full bg-white/12" />
+                  <div className="h-4 w-full animate-pulse rounded-full bg-white/12" />
                 </div>
               ))}
             </div>
 
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {Array.from({ length: 3 }).map((_, index) => (
-                <div key={`skeleton-action-${index}`} className="h-10 animate-pulse rounded-2xl bg-white/10" />
+                <div key={`skeleton-action-${index}`} className="h-10 animate-pulse rounded-2xl bg-white/12" />
               ))}
             </div>
 
-            <div className="h-8 w-3/4 animate-pulse rounded-2xl bg-white/10" />
+            <div className="h-8 w-3/4 animate-pulse rounded-2xl bg-white/12" />
           </div>
         ) : (
           <>
-            <div className={cn('grid grid-cols-1 gap-3 text-sm text-muted-foreground/90', 'sm:grid-cols-2')}>
+            <div className={cn('grid grid-cols-1 gap-3 rounded-2xl border border-white/12 bg-white/[0.06] p-4 text-sm text-white/80', 'sm:grid-cols-2')}>
               {infoRows(allocation).map((row) => {
                 const Icon = row.icon;
                 return (
                   <div key={row.label} className="space-y-1">
-                    <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.24em] text-muted-foreground/60">
-                      <Icon className="h-3.5 w-3.5" />
+                    <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.24em] text-white/65">
+                      <Icon className="h-3.5 w-3.5 text-white/70" />
                       <span>{row.label}</span>
                     </div>
-                    <p className="text-sm font-medium text-foreground/90">{row.value || '—'}</p>
+                    <p className="text-sm font-medium text-white/90">{row.value || '—'}</p>
                   </div>
                 );
               })}
@@ -170,7 +170,7 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
                 size="sm"
                 onClick={() => (allocation && onOpenWhatsApp ? onOpenWhatsApp(allocation) : null)}
                 disabled={!allocation?.phone || !onOpenWhatsApp || showSkeleton}
-                className="group flex items-center justify-center gap-2 rounded-2xl bg-emerald-500/90 px-4 py-3 text-sm font-medium text-emerald-950 shadow-[0_10px_30px_rgba(16,185,129,0.35)] transition hover:bg-emerald-400"
+                className="group flex items-center justify-center gap-2 rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-medium text-emerald-950 shadow-[0_12px_34px_rgba(16,185,129,0.45)] transition hover:bg-emerald-400"
               >
                 <Phone className="h-4 w-4" /> Abrir conversa
               </Button>
@@ -186,7 +186,7 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
                     onClick={() =>
                       allocation && onUpdateStatus ? onUpdateStatus(allocation.allocationId, action.status) : null
                     }
-                    className="flex items-center justify-center gap-2 rounded-2xl border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-foreground/90 transition hover:border-white/30 hover:bg-white/10"
+                    className="flex items-center justify-center gap-2 rounded-2xl border-white/15 bg-white/[0.08] px-4 py-3 text-sm font-medium text-white/90 transition hover:border-white/30 hover:bg-white/[0.12]"
                   >
                     <Icon className="h-4 w-4" />
                     {action.label}
@@ -196,8 +196,8 @@ const LeadProfilePanel = ({ allocation, onUpdateStatus, onOpenWhatsApp, isLoadin
             </div>
 
             {allocation?.email ? (
-              <div className="flex items-center gap-2 rounded-2xl border border-white/5 bg-white/5 px-3 py-2 text-xs text-muted-foreground/80">
-                <Mail className="h-4 w-4 text-muted-foreground/60" />
+              <div className="flex items-center gap-2 rounded-2xl border border-white/12 bg-white/[0.08] px-3 py-2 text-xs text-white/75">
+                <Mail className="h-4 w-4 text-white/65" />
                 <span>{allocation.email}</span>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- Refresh the inbox header, list column, and right-hand panels with layered dark surfaces, vertical dividers, and clearer spacing to mirror the Reports & Insights hierarchy.
- Elevate lead cards, timeline, and profile details with brighter typography, refined status badges, and modular sub-sections for better readability.
- Harmonize action widgets and empty states with consistent glassmorphism, shadows, and contrast-compliant color accents across the inbox.

## Testing
- `pnpm lint` *(fails: pre-existing react-refresh lint error in apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e570caa9208332acb958e6cb78f8ca