### PR TITLE
feat: add scrollable lead inbox surface

### DIFF
--- a/apps/web/src/features/leads/inbox/components/InboxList.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxList.jsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils.js';
+
 import LeadAllocationCard from './LeadAllocationCard.jsx';
 import EmptyInboxState from './EmptyInboxState.jsx';
 
@@ -12,10 +14,11 @@ export const InboxList = ({
   onSelectAllocation,
   activeAllocationId,
   onOpenWhatsApp,
+  className,
 }) => {
   if (loading) {
     return (
-      <div className="space-y-3" aria-live="polite" aria-busy="true">
+      <div className={cn('space-y-3', className)} aria-live="polite" aria-busy="true">
         <span className="sr-only">Carregando leads…</span>
         {Array.from({ length: 4 }).map((_, index) => (
           <div
@@ -69,14 +72,19 @@ export const InboxList = ({
 
   if (filteredAllocations.length === 0) {
     return (
-      <div className="rounded-[24px] border border-dashed border-white/12 bg-[#101d33] p-6 text-center text-sm text-white/75 shadow-[0_18px_44px_rgba(3,9,24,0.45)]">
+      <div
+        className={cn(
+          'rounded-[24px] border border-dashed border-white/12 bg-[#101d33] p-6 text-center text-sm text-white/75 shadow-[0_18px_44px_rgba(3,9,24,0.45)]',
+          className
+        )}
+      >
         Nenhum lead com o filtro selecionado.
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <div className={cn('space-y-3', className)}>
       {filteredAllocations.map((allocation) => (
         <LeadAllocationCard
           key={allocation.allocationId}

--- a/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadConversationPanel.jsx
@@ -191,8 +191,8 @@ const LeadConversationPanel = ({ allocation, onOpenWhatsApp, isLoading, isSwitch
     ]) ?? allocation?.notes ?? null;
 
   return (
-    <div className="flex h-full min-h-[520px] flex-col rounded-[32px] border border-white/12 bg-[#111f38] shadow-[0_26px_60px_rgba(3,8,23,0.55)] ring-1 ring-white/10">
-      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/12 bg-white/[0.04] px-6 py-4 shadow-[0_16px_30px_rgba(4,9,24,0.35)]">
+    <div className="flex h-full min-h-[520px] flex-col rounded-[32px] border border-white/15 bg-slate-950/50 shadow-[0_30px_64px_-42px_rgba(15,23,42,0.9)] ring-1 ring-white/10 backdrop-blur-xl">
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/12 bg-white/[0.05] px-6 py-4 shadow-[0_20px_38px_-28px_rgba(15,23,42,0.9)]">
         <div className="space-y-2">
           <p className="text-[11px] font-medium uppercase tracking-[0.3em] text-white/70">Timeline</p>
           <div className="flex flex-wrap items-center gap-3">

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -699,8 +699,8 @@ export const LeadInbox = ({
       />
 
       <div className="grid gap-6 xl:grid-cols-[300px_minmax(0,1fr)_340px] xl:gap-7">
-        <div className="relative">
-          <section className="flex min-h-[520px] flex-col gap-5 rounded-[28px] border border-white/10 bg-[#0c192e] p-5 shadow-[0_24px_52px_rgba(4,10,24,0.55)] ring-1 ring-white/10 xl:max-h-[calc(100vh-220px)] xl:overflow-hidden">
+        <div className="relative xl:h-[calc(100vh-220px)] xl:min-h-[520px]">
+          <section className="flex h-full min-h-[520px] min-w-0 flex-col gap-5 rounded-[28px] border border-white/15 bg-slate-950/45 p-5 shadow-[0_32px_64px_-40px_rgba(15,23,42,0.95)] ring-1 ring-white/10 backdrop-blur-xl">
             <GlobalFiltersBar
               filters={filters}
               onUpdateFilters={handleUpdateFilters}
@@ -718,20 +718,23 @@ export const LeadInbox = ({
 
             <div className="h-px bg-white/12" />
 
-            <div className="flex-1 overflow-y-auto pr-1 xl:pr-2">
-              <InboxList
-                allocations={allocations}
-                filteredAllocations={filteredAllocations}
-                loading={loading}
-              selectedAgreement={selectedAgreement}
-              campaign={campaign}
-              onBackToWhatsApp={onBackToWhatsApp}
-              onSelectAgreement={onSelectAgreement}
-              onSelectAllocation={handleSelectAllocation}
-              activeAllocationId={activeAllocationId}
-              onOpenWhatsApp={handleOpenWhatsApp}
-            />
-          </div>
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <div className="h-full overflow-y-auto pr-1 xl:pr-2">
+                <InboxList
+                  allocations={allocations}
+                  filteredAllocations={filteredAllocations}
+                  loading={loading}
+                  selectedAgreement={selectedAgreement}
+                  campaign={campaign}
+                  onBackToWhatsApp={onBackToWhatsApp}
+                  onSelectAgreement={onSelectAgreement}
+                  onSelectAllocation={handleSelectAllocation}
+                  activeAllocationId={activeAllocationId}
+                  onOpenWhatsApp={handleOpenWhatsApp}
+                  className="pb-3"
+                />
+              </div>
+            </div>
 
             <div className="space-y-3 text-sm">
               {!realtimeConnected && !connectionError ? (
@@ -793,7 +796,7 @@ export const LeadInbox = ({
           </div>
         </div>
 
-        <aside className="flex min-h-[520px] flex-col gap-4 rounded-[28px] border border-white/12 bg-[#162946] p-5 shadow-[0_24px_52px_rgba(6,14,38,0.55)] ring-1 ring-white/10">
+        <aside className="flex min-h-[520px] flex-col gap-4 rounded-[28px] border border-white/15 bg-slate-950/40 p-5 shadow-[0_28px_60px_-42px_rgba(15,23,42,0.9)] ring-1 ring-white/10 backdrop-blur-xl">
           <Card className="rounded-3xl border-white/15 bg-white/[0.08] shadow-[0_18px_40px_rgba(5,12,30,0.45)]">
             <CardHeader className="space-y-2 pb-2">
               <CardTitle className="text-sm font-semibold uppercase tracking-[0.24em] text-white/80">


### PR DESCRIPTION
## Summary
- bound the lead inbox column height and add an internal scroll container to keep the list stable
- expose styling hooks on the lead list and refresh the inbox surfaces with higher-contrast panels
- update the conversation panel background to match the renewed inbox contrast treatment

## Testing
- pnpm --filter web lint *(fails: existing parsing error in apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a23b68e883329dc79b2dc9537c01