### PR TITLE
Add scroll handling for the lead inbox selection

### DIFF
--- a/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
@@ -52,6 +52,8 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
       type="button"
       onClick={() => onSelect?.(allocation)}
       onDoubleClick={() => (allocation && onDoubleOpen ? onDoubleOpen(allocation) : null)}
+      data-allocation-id={allocation?.allocationId ?? undefined}
+      aria-current={isActive ? 'true' : undefined}
       className={cn(
         'group flex w-full flex-col gap-4 rounded-[24px] border border-white/12 bg-[#101d33] p-5 text-left shadow-[0_18px_44px_rgba(3,9,24,0.45)] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#070f1f] hover:border-white/20 hover:shadow-[0_26px_54px_rgba(5,12,30,0.55)]',
         isActive

--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -348,6 +348,7 @@ export const LeadInbox = ({
   const [autoRefreshSeconds, setAutoRefreshSeconds] = useState(null);
   const [activeAllocationId, setActiveAllocationId] = useState(null);
   const [leadPanelSwitching, setLeadPanelSwitching] = useState(false);
+  const inboxScrollRef = useRef(null);
 
   const {
     allocations,
@@ -562,14 +563,43 @@ export const LeadInbox = ({
   }, []);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
     if (!activeAllocationId) {
       setLeadPanelSwitching(false);
-      return;
+      return undefined;
+    }
+
+    const viewport = inboxScrollRef.current?.node ?? inboxScrollRef.current ?? null;
+    if (viewport) {
+      const rawId = String(activeAllocationId);
+      const escapedId = window.CSS?.escape
+        ? window.CSS.escape(rawId)
+        : rawId.replace(/(["\\])/g, '\\$1');
+      const selector = `[data-allocation-id="${escapedId}"]`;
+      const activeElement = viewport.querySelector(selector);
+
+      if (activeElement) {
+        if (document.activeElement !== activeElement && typeof activeElement.focus === 'function') {
+          activeElement.focus({ preventScroll: true });
+        }
+
+        if (typeof activeElement.scrollIntoView === 'function') {
+          activeElement.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+            behavior: firstActiveSelectionRef.current ? 'auto' : 'smooth',
+          });
+        }
+      }
     }
 
     if (firstActiveSelectionRef.current) {
       firstActiveSelectionRef.current = false;
-      return;
+      setLeadPanelSwitching(false);
+      return undefined;
     }
 
     setLeadPanelSwitching(true);
@@ -751,7 +781,11 @@ export const LeadInbox = ({
               />
             </div>
 
-            <ColumnScrollArea className="flex-1 min-h-0" viewportClassName="space-y-5 px-5 pb-6 pr-6 pt-5">
+            <ColumnScrollArea
+              ref={inboxScrollRef}
+              className="flex-1 min-h-0"
+              viewportClassName="space-y-5 px-5 pb-6 pr-6 pt-5"
+            >
               <InboxList
                 allocations={allocations}
                 filteredAllocations={filteredAllocations}


### PR DESCRIPTION
## Summary
- pass a scroll ref from `LeadInbox` to the inbox column so the active card can be located and scrolled into view
- focus and scroll the active allocation card whenever the selection changes while keeping the focus ring styles intact
- tag each lead allocation card with its allocation id to enable targeted scrolling and accessibility metadata

## Testing
- pnpm --filter web lint *(fails: existing parsing error in apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6437601548332970e4ce93a62a4e0