### PR TITLE
Refine inbox lead card surfaces

### DIFF
--- a/apps/web/src/features/leads/inbox/components/InboxList.jsx
+++ b/apps/web/src/features/leads/inbox/components/InboxList.jsx
@@ -23,7 +23,7 @@ export const InboxList = ({
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`allocation-skeleton-${index}`}
-            className="space-y-4 rounded-[24px] border border-white/12 bg-[#101d33] p-5 shadow-[0_18px_44px_rgba(3,9,24,0.45)]"
+            className="space-y-4 rounded-[24px] border border-white/12 bg-slate-950/45 p-5 shadow-[0_18px_44px_rgba(3,9,24,0.45)] backdrop-blur-xl"
           >
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-2">
@@ -74,7 +74,7 @@ export const InboxList = ({
     return (
       <div
         className={cn(
-          'rounded-[24px] border border-dashed border-white/12 bg-[#101d33] p-6 text-center text-sm text-white/75 shadow-[0_18px_44px_rgba(3,9,24,0.45)]',
+          'rounded-[24px] border border-dashed border-white/12 bg-slate-950/45 p-6 text-center text-sm text-muted-foreground shadow-[0_18px_44px_rgba(3,9,24,0.45)] backdrop-blur-xl',
           className
         )}
       >

--- a/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadAllocationCard.jsx
@@ -9,10 +9,10 @@ const STATUS_LABEL = {
 };
 
 const STATUS_TONE = {
-  allocated: 'border-white/20 bg-white/[0.08] text-white/80',
-  contacted: 'border-sky-400/40 bg-sky-500/20 text-sky-100',
-  won: 'border-emerald-400/45 bg-emerald-400/20 text-emerald-100',
-  lost: 'border-rose-500/50 bg-rose-500/18 text-rose-100',
+  allocated: 'border-white/15 bg-white/[0.08] text-foreground/80',
+  contacted: 'border-primary/40 bg-primary/15 text-foreground',
+  won: 'border-emerald-400/45 bg-emerald-400/20 text-foreground',
+  lost: 'border-rose-500/50 bg-rose-500/18 text-foreground',
 };
 
 const formatCurrency = (value) => {
@@ -55,26 +55,26 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
       data-allocation-id={allocation?.allocationId ?? undefined}
       aria-current={isActive ? 'true' : undefined}
       className={cn(
-        'group flex w-full flex-col gap-4 rounded-[24px] border border-white/12 bg-[#101d33] p-5 text-left shadow-[0_18px_44px_rgba(3,9,24,0.45)] transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#070f1f] hover:border-white/20 hover:shadow-[0_26px_54px_rgba(5,12,30,0.55)]',
+        'group flex w-full flex-col gap-4 rounded-[24px] border border-white/12 bg-slate-950/45 p-5 text-left text-foreground shadow-[0_18px_44px_rgba(3,9,24,0.45)] transition-all duration-200 ease-out backdrop-blur-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 hover:border-primary/40 hover:bg-primary/15 hover:shadow-[0_26px_54px_rgba(5,12,30,0.55)]',
         isActive
-          ? 'border-sky-400/60 bg-sky-500/20 shadow-[0_30px_70px_rgba(14,116,144,0.35)] focus-visible:ring-sky-300'
-          : 'hover:bg-[#13223d]'
+          ? 'border-primary/60 bg-primary/15 shadow-[0_30px_70px_rgba(15,23,42,0.45)] focus-visible:ring-primary'
+          : null
       )}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-1.5">
-          <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-white/65">Lead</p>
+          <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-muted-foreground">Lead</p>
           <div className="space-y-0.5">
-            <h3 className="text-base font-semibold leading-snug text-white/95 group-hover:text-white">
+            <h3 className="text-base font-semibold leading-snug text-foreground">
               {allocation.fullName}
             </h3>
-            <p className="text-[13px] text-white/75">{formatDocument(allocation.document)}</p>
+            <p className="text-[13px] text-muted-foreground">{formatDocument(allocation.document)}</p>
           </div>
         </div>
         <Badge
           variant="outline"
           className={cn(
-            'border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] text-white/80 transition-colors',
+            'border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.24em] text-foreground transition-colors',
             statusTone
           )}
         >
@@ -82,29 +82,29 @@ export const LeadAllocationCard = ({ allocation, isActive, onSelect, onDoubleOpe
         </Badge>
       </div>
 
-      <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.04] p-3 text-[13px] text-white/80 sm:grid-cols-3">
+      <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.04] p-3 text-[13px] text-muted-foreground sm:grid-cols-3">
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Telefone</p>
-          <p className="font-medium text-white/90">{allocation.phone ?? '—'}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Telefone</p>
+          <p className="font-medium text-foreground">{allocation.phone ?? '—'}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Score</p>
-          <p className="font-medium text-white/90">{allocation.score ?? '—'}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Score</p>
+          <p className="font-medium text-foreground">{allocation.score ?? '—'}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Registros</p>
-          <p className="font-medium text-white/90">{resolveRegistrations(allocation.registrations)}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Registros</p>
+          <p className="font-medium text-foreground">{resolveRegistrations(allocation.registrations)}</p>
         </div>
       </div>
 
       <div className="grid gap-3 border-t border-white/10 pt-4 text-[13px] sm:grid-cols-2">
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Margem bruta</p>
-          <p className="text-[15px] font-semibold text-white/92">{formatCurrency(allocation.margin)}</p>
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Margem bruta</p>
+          <p className="text-[15px] font-semibold text-foreground">{formatCurrency(allocation.margin)}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-[10px] uppercase tracking-[0.24em] text-white/60">Margem disponível</p>
-          <p className="text-[15px] font-semibold text-white/92">
+          <p className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Margem disponível</p>
+          <p className="text-[15px] font-semibold text-foreground">
             {formatCurrency(allocation.netMargin ?? allocation.margin)}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- align the lead allocation card with the inbox glass surface and primary-colored focus/hover states
- switch card typography to semantic foreground tokens while keeping status badges legible
- update skeleton and empty inbox surfaces to match the refreshed treatment

## Testing
- pnpm --filter web lint *(fails: existing parsing error in apps/web/src/features/chat/components/SidebarInbox/InboxItem.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e6455bede483328c87df388fe09bf1