### PR TITLE
Improve health indicator resilience and tooltip accessibility

### DIFF
--- a/apps/web/src/components/HealthIndicator.jsx
+++ b/apps/web/src/components/HealthIndicator.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { apiGet } from '@/lib/api.js';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { API_BASE_URL, apiGet } from '@/lib/api.js';
 
 const STATUS_COLORS = {
   ok: { dot: '#22c55e', bg: 'rgba(34,197,94,0.12)', fg: '#14532d' },
@@ -10,6 +10,82 @@ const STATUS_COLORS = {
 export default function HealthIndicator({ intervalMs = 30000 }) {
   const [status, setStatus] = useState('unknown');
   const [details, setDetails] = useState({});
+  const fallbackOrigins = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    const origins = new Set();
+    const normalizedBase = typeof API_BASE_URL === 'string' ? API_BASE_URL.trim() : '';
+    if (normalizedBase) {
+      origins.add(normalizedBase.replace(/\/$/, ''));
+    }
+
+    origins.add(window.location.origin.replace(/\/$/, ''));
+
+    return Array.from(origins, (origin) => `${origin}/health`);
+  }, []);
+
+  const normalizeStatus = useCallback((value) => {
+    if (typeof value !== 'string') {
+      return 'unknown';
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (['ok', 'healthy', 'up'].includes(normalized)) {
+      return 'ok';
+    }
+    if (['down', 'unhealthy', 'error'].includes(normalized)) {
+      return 'unhealthy';
+    }
+    return normalized || 'unknown';
+  }, []);
+
+  const normalizePayload = useCallback(
+    (payload) => {
+      if (!payload) {
+        return { status: 'unknown', details: {} };
+      }
+
+      if (typeof payload === 'string') {
+        return {
+          status: normalizeStatus(payload),
+          details: { message: payload },
+        };
+      }
+
+      const candidateStatus =
+        typeof payload.status === 'string'
+          ? payload.status
+          : typeof payload.state === 'string'
+          ? payload.state
+          : typeof payload.health === 'string'
+          ? payload.health
+          : payload.success === true
+          ? 'ok'
+          : 'unknown';
+
+      return {
+        status: normalizeStatus(candidateStatus),
+        details: payload,
+      };
+    },
+    [normalizeStatus]
+  );
+
+  const parseResponse = useCallback(async (response) => {
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      return response.json().catch(() => ({}));
+    }
+
+    const text = await response.text().catch(() => '');
+    if (!text) {
+      return {};
+    }
+
+    return { status: text, message: text };
+  }, []);
 
   useEffect(() => {
     let alive = true;
@@ -17,13 +93,45 @@ export default function HealthIndicator({ intervalMs = 30000 }) {
       try {
         const payload = await apiGet('/health');
         if (!alive) return;
-        const st = payload?.status ?? 'unknown';
-        setStatus(st);
-        setDetails(payload);
+        const normalized = normalizePayload(payload);
+        setStatus(normalized.status);
+        setDetails(normalized.details);
       } catch (err) {
         if (!alive) return;
+
+        for (const url of fallbackOrigins) {
+          try {
+            const response = await fetch(url, {
+              method: 'GET',
+              credentials: 'omit',
+              cache: 'no-store',
+              headers: { Accept: 'application/json' },
+            });
+
+            if (!response.ok) {
+              continue;
+            }
+
+            const payload = await parseResponse(response);
+            if (!alive) return;
+
+            const normalized = normalizePayload({ ...payload, source: url });
+            setStatus(normalized.status);
+            setDetails(normalized.details);
+            return;
+          } catch (fallbackError) {
+            console.debug('Health check fallback failed', url, fallbackError);
+          }
+        }
+
+        if (!alive) return;
+        const errorPayload = {
+          error: err instanceof Error ? err.message : String(err),
+          status: err?.status ?? err?.statusCode ?? null,
+          timestamp: new Date().toISOString(),
+        };
         setStatus('unhealthy');
-        setDetails({ error: err instanceof Error ? err.message : String(err) });
+        setDetails(errorPayload);
       }
     };
 
@@ -33,7 +141,7 @@ export default function HealthIndicator({ intervalMs = 30000 }) {
       alive = false;
       clearInterval(id);
     };
-  }, [intervalMs]);
+  }, [fallbackOrigins, intervalMs, normalizePayload, parseResponse]);
 
   const palette = STATUS_COLORS[status] || STATUS_COLORS.unknown;
   const title = status === 'ok' ? 'Serviço operacional' : status === 'unhealthy' ? 'Indisponível' : 'Desconhecido';

--- a/apps/web/src/components/ui/tooltip.jsx
+++ b/apps/web/src/components/ui/tooltip.jsx
@@ -1,20 +1,33 @@
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delayDuration = 0,
-  ...props
-}) {
-  return (<TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />);
-}
-
-function Tooltip({
+  skipDelayDuration = 300,
   ...props
 }) {
   return (
-    <TooltipProvider>
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  delayDuration,
+  skipDelayDuration,
+  ...props
+}) {
+  return (
+    <TooltipProvider
+      delayDuration={delayDuration}
+      skipDelayDuration={skipDelayDuration}
+    >
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
     </TooltipProvider>
   );
@@ -41,13 +54,13 @@ function TooltipContent({
           "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
-        {...props}>
+        {...props}
+      >
         {children}
-        <TooltipPrimitive.Arrow
-          className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/apps/web/src/features/chat/components/ConversationArea/MessageBubble.jsx
+++ b/apps/web/src/features/chat/components/ConversationArea/MessageBubble.jsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.jsx';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.jsx';
 import { cn } from '@/lib/utils.js';
 import { Check, CheckCheck, BadgeCheck, AlertTriangle } from 'lucide-react';
 import AttachmentPreview from '../Shared/AttachmentPreview.jsx';
@@ -41,16 +41,21 @@ export const MessageBubble = ({ message }) => {
         <AttachmentPreview attachments={message.attachments} />
         <div className="mt-1 flex items-center gap-1 text-[11px] text-slate-400">
           <span>{formatTime(message.createdAt)}</span>
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className={cn('inline-flex items-center gap-1', ack.tone)}>
-                  <ack.icon className="h-3 w-3" />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>{ack.label}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip delayDuration={200}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full px-1.5 py-1 text-[11px] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  ack.tone
+                )}
+                aria-label={ack.label}
+              >
+                <ack.icon className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{ack.label}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add health check fallback handling and payload normalization to keep the status indicator stable when the primary request fails
- expose tooltip provider timing controls so components can customise delays without nesting providers
- render chat acknowledgement icons as accessible tooltip triggers to avoid DOM lookup errors

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e6504a007c83329a837b5f712cbe50