### PR TITLE
feat(web): add theme provider and light palette

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,25 +1,48 @@
 :root {
-  --bg: #0f172a;
-  --text: #f1f5f9;
-  --text-muted: #94a3b8;
-  --divider: rgba(124, 138, 163, 0.35);
-  --primary: #6366f1;
-  --primary-foreground: #f8fafc;
-  --success: #22c55e;
-  --warning: #facc15;
-  --error: #ef4444;
-  --surface: rgba(124, 138, 163, 0.14);
-  --surface-strong: rgba(124, 138, 163, 0.22);
+  color-scheme: light;
+  --bg: #f8fafc;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --divider: rgba(15, 23, 42, 0.08);
+  --primary: #4f46e5;
+  --primary-foreground: #eef2ff;
+  --success: #16a34a;
+  --warning: #d97706;
+  --error: #dc2626;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-strong: rgba(255, 255, 255, 0.92);
   --radius: 12px;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
-  --border: #7c8aa3;
+  --border: rgba(15, 23, 42, 0.12);
   --space-1: 8px;
   --space-2: 16px;
   --space-3: 24px;
   --space-4: 32px;
+  --input: rgba(15, 23, 42, 0.18);
+  --secondary: rgba(79, 70, 229, 0.1);
+  --secondary-foreground: var(--text);
+  --muted: rgba(148, 163, 184, 0.16);
+  --muted-foreground: var(--text-muted);
+  --accent: rgba(79, 70, 229, 0.16);
+  --accent-foreground: var(--text);
+  --destructive: var(--error);
+  --ring: rgba(79, 70, 229, 0.55);
+  --chart-1: #4f46e5;
+  --chart-2: #0ea5e9;
+  --chart-3: #f97316;
+  --chart-4: #16a34a;
+  --chart-5: #facc15;
+  --sidebar: rgba(255, 255, 255, 0.85);
+  --sidebar-foreground: var(--text);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: rgba(79, 70, 229, 0.1);
+  --sidebar-accent-foreground: var(--text);
+  --sidebar-border: rgba(15, 23, 42, 0.1);
+  --sidebar-ring: rgba(79, 70, 229, 0.25);
 
   --background: var(--bg);
   --foreground: var(--text);
@@ -27,29 +50,6 @@
   --card-foreground: var(--text);
   --popover: var(--surface-strong);
   --popover-foreground: var(--text);
-  --secondary: rgba(99, 102, 241, 0.12);
-  --secondary-foreground: var(--text);
-  --muted: rgba(148, 163, 184, 0.08);
-  --muted-foreground: var(--text-muted);
-  --accent: rgba(99, 102, 241, 0.18);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
-  --input: #7c8aa3;
-  --ring: var(--primary);
-  --chart-1: #6366f1;
-  --chart-2: #22d3ee;
-  --chart-3: #f97316;
-  --chart-4: #22c55e;
-  --chart-5: #facc15;
-  --sidebar: rgba(15, 23, 42, 0.96);
-  --sidebar-foreground: var(--text);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: rgba(148, 163, 184, 0.12);
-  --sidebar-accent-foreground: var(--text);
-  --sidebar-border: rgba(255, 255, 255, 0.12);
-  --sidebar-ring: rgba(99, 102, 241, 0.4);
-
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -84,21 +84,27 @@
 }
 
 .dark {
-  --background: var(--bg);
-  --foreground: var(--text);
-  --card: var(--surface);
-  --card-foreground: var(--text);
-  --popover: var(--surface-strong);
-  --popover-foreground: var(--text);
-  --secondary: rgba(99, 102, 241, 0.12);
-  --secondary-foreground: var(--text);
-  --muted: rgba(148, 163, 184, 0.08);
-  --muted-foreground: var(--text-muted);
-  --accent: rgba(99, 102, 241, 0.18);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
+  color-scheme: dark;
+  --bg: #0f172a;
+  --text: #f1f5f9;
+  --text-muted: #94a3b8;
+  --divider: rgba(124, 138, 163, 0.35);
+  --primary: #6366f1;
+  --primary-foreground: #f8fafc;
+  --success: #22c55e;
+  --warning: #facc15;
+  --error: #ef4444;
+  --surface: rgba(124, 138, 163, 0.14);
+  --surface-strong: rgba(124, 138, 163, 0.22);
   --border: #7c8aa3;
   --input: #7c8aa3;
+  --secondary: rgba(99, 102, 241, 0.12);
+  --muted: rgba(148, 163, 184, 0.08);
+  --accent: rgba(99, 102, 241, 0.18);
+  --secondary-foreground: var(--text);
+  --muted-foreground: var(--text-muted);
+  --accent-foreground: var(--text);
+  --destructive: var(--error);
   --ring: var(--primary);
   --sidebar: rgba(15, 23, 42, 0.96);
   --sidebar-foreground: var(--text);
@@ -117,11 +123,16 @@
   }
   body {
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: var(--text);
-    background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.15), transparent 45%),
-      radial-gradient(circle at bottom right, rgba(34, 197, 94, 0.08), transparent 50%),
-      var(--bg);
+    color: var(--foreground);
+    background-color: var(--background);
+    background-image:
+      radial-gradient(circle at top left, color-mix(in srgb, var(--primary) 18%, transparent) 0%, transparent 50%),
+      radial-gradient(circle at bottom right, color-mix(in srgb, var(--success) 14%, transparent) 0%, transparent 55%);
+    background-repeat: no-repeat;
+    background-size: 70% 70%, 75% 75%;
+    background-attachment: fixed;
     min-height: 100vh;
+    transition: background-color 150ms ease, color 150ms ease;
   }
 }
 

--- a/apps/web/src/components/HealthIndicator.jsx
+++ b/apps/web/src/components/HealthIndicator.jsx
@@ -2,9 +2,24 @@ import { useEffect, useState } from 'react';
 import { apiGet } from '@/lib/api.js';
 
 const STATUS_COLORS = {
-  ok: { dot: '#22c55e', bg: 'rgba(34,197,94,0.12)', fg: '#14532d' },
-  unhealthy: { dot: '#ef4444', bg: 'rgba(239,68,68,0.12)', fg: '#7f1d1d' },
-  unknown: { dot: '#f59e0b', bg: 'rgba(245,158,11,0.12)', fg: '#7c2d12' },
+  ok: {
+    dot: 'var(--success)',
+    bg: 'color-mix(in srgb, var(--success) 18%, transparent)',
+    fg: 'color-mix(in srgb, var(--success) 38%, var(--foreground))',
+    border: '1px solid color-mix(in srgb, var(--success) 28%, transparent)',
+  },
+  unhealthy: {
+    dot: 'var(--error)',
+    bg: 'color-mix(in srgb, var(--error) 20%, transparent)',
+    fg: 'color-mix(in srgb, var(--error) 40%, var(--foreground))',
+    border: '1px solid color-mix(in srgb, var(--error) 30%, transparent)',
+  },
+  unknown: {
+    dot: 'var(--warning)',
+    bg: 'color-mix(in srgb, var(--warning) 20%, transparent)',
+    fg: 'color-mix(in srgb, var(--warning) 42%, var(--foreground))',
+    border: '1px solid color-mix(in srgb, var(--warning) 30%, transparent)',
+  },
 };
 
 export default function HealthIndicator({ intervalMs = 30000 }) {
@@ -41,7 +56,7 @@ export default function HealthIndicator({ intervalMs = 30000 }) {
   return (
     <div
       className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs"
-      style={{ background: palette.bg, color: palette.fg }}
+      style={{ background: palette.bg, color: palette.fg, border: palette.border }}
       title={JSON.stringify(details)}
     >
       <span

--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -15,7 +15,10 @@ import {
   LogOut,
   ChevronsLeft,
   ChevronsRight,
+  Sun,
+  Moon,
 } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button.jsx';
 import { Input } from '@/components/ui/input.jsx';
 import './Layout.css';
@@ -29,12 +32,18 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
   const [inboxCount, setInboxCount] = useState(
     typeof onboarding?.metrics?.inboxCount === 'number' ? onboarding.metrics.inboxCount : null
   );
+  const [themeMounted, setThemeMounted] = useState(false);
+  const { resolvedTheme, setTheme } = useTheme();
 
   useEffect(() => {
     if (typeof onboarding?.metrics?.inboxCount === 'number') {
       setInboxCount(onboarding.metrics.inboxCount);
     }
   }, [onboarding?.metrics?.inboxCount]);
+
+  useEffect(() => {
+    setThemeMounted(true);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -83,6 +92,7 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
   }, [sidebarOpen]);
 
   const shouldShowOnboardingTrack = stageList.length > 0 && currentPage !== 'inbox';
+  const isDarkMode = themeMounted ? resolvedTheme === 'dark' : false;
 
   return (
     <div className="layout-container">
@@ -179,6 +189,24 @@ const Layout = ({ children, currentPage = 'dashboard', onNavigate, onboarding })
           </div>
 
           <div className="header-right" style={{ gap: 12 }}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setTheme(isDarkMode ? 'light' : 'dark')}
+              aria-label={isDarkMode ? 'Ativar tema claro' : 'Ativar tema escuro'}
+              title={isDarkMode ? 'Ativar tema claro' : 'Ativar tema escuro'}
+            >
+              {themeMounted ? (
+                isDarkMode ? (
+                  <Moon className="h-5 w-5" aria-hidden="true" />
+                ) : (
+                  <Sun className="h-5 w-5" aria-hidden="true" />
+                )
+              ) : (
+                <Sun className="h-5 w-5 opacity-0" aria-hidden="true" />
+              )}
+              <span className="sr-only">Alternar tema</span>
+            </Button>
             <DemoAuthDialog />
             <TenantSelector />
             <Button variant="ghost" size="sm" className="notification-btn">

--- a/apps/web/src/components/theme/theme-provider.jsx
+++ b/apps/web/src/components/theme/theme-provider.jsx
@@ -1,0 +1,18 @@
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+export function ThemeProvider({ children, ...props }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      storageKey="leadengine-theme"
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}
+
+export default ThemeProvider;

--- a/apps/web/src/features/leads/inbox/styles/tokens.css
+++ b/apps/web/src/features/leads/inbox/styles/tokens.css
@@ -1,6 +1,11 @@
 :root {
-  --inbox-glass-bg: rgba(148, 163, 184, 0.08);
-  --inbox-glass-border: rgba(148, 163, 184, 0.25);
+  --inbox-glass-bg: color-mix(in srgb, var(--background) 88%, var(--foreground) 12%);
+  --inbox-glass-border: color-mix(in srgb, var(--foreground) 18%, transparent);
+}
+
+.dark {
+  --inbox-glass-bg: color-mix(in srgb, var(--background) 78%, var(--foreground) 22%);
+  --inbox-glass-border: color-mix(in srgb, var(--foreground) 28%, transparent);
 }
 
 .inbox-glass-surface {

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import App from './App.jsx';
 import { Toaster } from '@/components/ui/sonner.jsx';
+import { ThemeProvider } from '@/components/theme/theme-provider.jsx';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,8 +19,10 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
-      <Toaster richColors position="top-right" />
+      <ThemeProvider>
+        <App />
+        <Toaster richColors position="top-right" />
+      </ThemeProvider>
     </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add a Next Themes provider that persists the selected mode and wrap the web app entry with it
- refresh global design tokens for light and dark palettes and align inbox glass tokens with the new scheme
- expose a theme toggle in the layout header and update health indicator styling to rely on theme variables

## Testing
- pnpm --filter web lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6544a8d088332aa800b637228fd1e