### PR TITLE
refactor: centralize web theme tokens

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,126 +1,23 @@
-:root {
-  --bg: #0f172a;
-  --text: #f1f5f9;
-  --text-muted: #94a3b8;
-  --divider: rgba(124, 138, 163, 0.35);
-  --primary: #6366f1;
-  --primary-foreground: #f8fafc;
-  --success: #22c55e;
-  --warning: #facc15;
-  --error: #ef4444;
-  --surface: rgba(124, 138, 163, 0.14);
-  --surface-strong: rgba(124, 138, 163, 0.22);
-  --radius: 12px;
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --border: #7c8aa3;
-  --space-1: 8px;
-  --space-2: 16px;
-  --space-3: 24px;
-  --space-4: 32px;
-
-  --background: var(--bg);
-  --foreground: var(--text);
-  --card: var(--surface);
-  --card-foreground: var(--text);
-  --popover: var(--surface-strong);
-  --popover-foreground: var(--text);
-  --secondary: rgba(99, 102, 241, 0.12);
-  --secondary-foreground: var(--text);
-  --muted: rgba(148, 163, 184, 0.08);
-  --muted-foreground: var(--text-muted);
-  --accent: rgba(99, 102, 241, 0.18);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
-  --input: #7c8aa3;
-  --ring: var(--primary);
-  --chart-1: #6366f1;
-  --chart-2: #22d3ee;
-  --chart-3: #f97316;
-  --chart-4: #22c55e;
-  --chart-5: #facc15;
-  --sidebar: rgba(15, 23, 42, 0.96);
-  --sidebar-foreground: var(--text);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: rgba(148, 163, 184, 0.12);
-  --sidebar-accent-foreground: var(--text);
-  --sidebar-border: rgba(255, 255, 255, 0.12);
-  --sidebar-ring: rgba(99, 102, 241, 0.4);
-
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-}
-
-.dark {
-  --background: var(--bg);
-  --foreground: var(--text);
-  --card: var(--surface);
-  --card-foreground: var(--text);
-  --popover: var(--surface-strong);
-  --popover-foreground: var(--text);
-  --secondary: rgba(99, 102, 241, 0.12);
-  --secondary-foreground: var(--text);
-  --muted: rgba(148, 163, 184, 0.08);
-  --muted-foreground: var(--text-muted);
-  --accent: rgba(99, 102, 241, 0.18);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
-  --border: #7c8aa3;
-  --input: #7c8aa3;
-  --ring: var(--primary);
-  --sidebar: rgba(15, 23, 42, 0.96);
-  --sidebar-foreground: var(--text);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: rgba(148, 163, 184, 0.12);
-  --sidebar-accent-foreground: var(--text);
-  --sidebar-border: rgba(255, 255, 255, 0.12);
-  --sidebar-ring: rgba(99, 102, 241, 0.4);
-}
-
 @layer base {
   * {
-    border-color: var(--border);
-    outline-color: color-mix(in srgb, var(--ring) 50%, transparent);
+    border-color: var(--color-border);
+    outline-color: color-mix(in srgb, var(--color-ring) 50%, transparent);
   }
+
   body {
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: var(--text);
-    background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.15), transparent 45%),
-      radial-gradient(circle at bottom right, rgba(34, 197, 94, 0.08), transparent 50%),
-      var(--bg);
+    color: var(--color-foreground);
+    background: radial-gradient(
+        circle at top left,
+        color-mix(in oklab, var(--color-primary) 15%, transparent),
+        transparent 45%
+      ),
+      radial-gradient(
+        circle at bottom right,
+        color-mix(in oklab, var(--color-success) 8%, transparent),
+        transparent 50%
+      ),
+      var(--color-background);
     min-height: 100vh;
   }
 }
@@ -129,36 +26,41 @@
   .app-container {
     margin: 0 auto;
     width: 100%;
-    max-width: 1280px;
-    padding: var(--space-4);
+    max-width: 80rem;
+    padding: var(--spacing-8);
   }
+
   .section-divider {
     height: 1px;
-    background: var(--divider);
+    background: var(--color-divider);
   }
+
   .glass-surface {
-    background: var(--surface);
-    border: 1px solid var(--border);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     backdrop-filter: blur(16px);
   }
+
   .filter-pill {
     padding: 0.25rem 0.75rem;
     border-radius: 9999px;
-    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    border: 1px solid color-mix(in oklab, var(--color-border) 60%, transparent);
     transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
     transition-duration: 150ms;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    color: var(--text-muted);
+    color: var(--color-muted-foreground);
     cursor: pointer;
     outline: none;
   }
+
   .filter-pill:hover {
-    background: color-mix(in oklab, var(--primary) 12%, transparent);
-    color: var(--foreground);
+    background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+    color: var(--color-foreground);
   }
+
   .filter-pill--active {
-    background: color-mix(in oklab, var(--primary) 24%, transparent);
-    border-color: color-mix(in oklab, var(--primary) 65%, transparent);
-    color: var(--primary-foreground);
+    background: color-mix(in oklab, var(--color-primary) 24%, transparent);
+    border-color: color-mix(in oklab, var(--color-primary) 65%, transparent);
+    color: var(--color-primary-foreground);
   }
 }

--- a/apps/web/src/components/Layout.css
+++ b/apps/web/src/components/Layout.css
@@ -1,22 +1,18 @@
+@reference '../index.css';
+
 /* Layout Container */
 .layout-container {
-  display: flex;
-  min-height: 100vh;
-  color: var(--text);
-  background: transparent;
+  @apply flex min-h-screen bg-transparent text-foreground;
 }
 
 /* Sidebar */
 .sidebar {
-  position: fixed;
-  inset: 0 auto 0 0;
-  z-index: 50;
+  @apply fixed inset-y-0 left-0 z-50 transition-[transform,width] duration-300 ease-in-out;
   width: var(--sidebar-width, 16rem);
   transform: translateX(-100%);
-  border-right: 1px solid var(--sidebar-border);
-  background: var(--sidebar);
+  border-right: 1px solid var(--color-sidebar-border);
+  background: var(--color-sidebar);
   backdrop-filter: blur(18px);
-  transition: transform 0.3s ease, width 0.3s ease;
 }
 
 .sidebar-collapsed {
@@ -35,8 +31,7 @@
 
 @media (min-width: 1024px) {
   .sidebar {
-    position: relative;
-    transform: translateX(0);
+    @apply relative translate-x-0;
   }
 
   .sidebar-collapsed {
@@ -45,58 +40,44 @@
 }
 
 .sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-3);
-  border-bottom: 1px solid var(--divider);
+  @apply flex items-center justify-between border-b p-6;
+  border-color: var(--color-divider);
 }
 
 .sidebar-logo {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+  @apply flex items-center gap-3;
 }
 
 .sidebar-collapsed .sidebar-logo {
-  justify-content: center;
-  gap: 0;
+  @apply justify-center gap-0;
 }
 
 .logo-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 16px;
-  background: color-mix(in oklab, var(--primary) 18%, transparent);
-  color: var(--primary-foreground);
+  @apply flex size-10 items-center justify-center rounded-2xl;
+  background: color-mix(in oklab, var(--color-primary) 18%, transparent);
+  color: var(--color-primary-foreground);
 }
 
 .logo-text h1 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin: 0;
+  @apply m-0 text-lg font-semibold;
 }
 
 .logo-text p {
-  margin: 0;
-  font-size: 0.75rem;
-  color: var(--text-muted);
+  @apply m-0 text-xs;
+  color: var(--color-muted-foreground);
 }
 
 .sidebar-collapsed .logo-text {
-  display: none;
+  @apply hidden;
 }
 
 .sidebar-close {
-  display: none;
+  @apply hidden;
 }
 
 @media (max-width: 1023px) {
   .sidebar-close {
-    display: inline-flex;
+    @apply inline-flex;
   }
 }
 
@@ -104,46 +85,36 @@
 .sidebar-nav {
   height: calc(100% - 88px);
   overflow-y: auto;
-  padding: var(--space-3);
+  @apply p-6;
 }
 
 .sidebar-collapsed .sidebar-nav {
-  padding: var(--space-3) 12px;
+  @apply px-3 py-6;
 }
 
 .nav-list {
-  display: grid;
-  gap: 8px;
+  @apply grid gap-2;
 }
 
 .nav-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: var(--radius);
-  font-size: 0.9rem;
-  font-weight: 500;
-  transition: background-color 0.2s ease, color 0.2s ease;
-  color: var(--text-muted);
+  @apply flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors;
+  color: var(--color-muted-foreground);
   background: transparent;
 }
 
 .nav-item:hover {
-  background: color-mix(in oklab, var(--primary) 10%, transparent);
-  color: var(--text);
+  background: color-mix(in oklab, var(--color-primary) 10%, transparent);
+  color: var(--color-foreground);
 }
 
 .nav-item-active {
-  background: color-mix(in oklab, var(--primary) 12%, transparent);
-  color: var(--text);
-  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--primary) 28%, transparent);
+  background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+  color: var(--color-foreground);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-primary) 28%, transparent);
 }
 
 .sidebar-collapsed .nav-item {
-  justify-content: center;
-  gap: 0;
-  padding: 10px 10px;
+  @apply justify-center gap-0 px-2.5;
 }
 
 .sidebar-collapsed .nav-item:hover {
@@ -152,264 +123,193 @@
 
 .sidebar-collapsed .nav-text,
 .sidebar-collapsed .nav-badge {
-  display: none;
+  @apply hidden;
 }
 
 .nav-icon {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
+  @apply h-5 w-5 flex-shrink-0;
 }
 
 .nav-text {
-  flex: 1;
-  text-align: left;
+  @apply flex-1 text-left;
 }
 
 .sidebar-collapsed .nav-icon {
-  margin: 0;
+  @apply m-0;
 }
 
 .nav-badge {
-  margin-left: auto;
+  @apply ml-auto;
 }
 
 /* Sidebar Footer */
 .sidebar-footer {
-  padding: var(--space-3);
-  border-top: 1px solid var(--divider);
+  @apply border-t p-6;
+  border-color: var(--color-divider);
 }
 
 .sidebar-collapsed .sidebar-footer {
-  padding: var(--space-3) 0;
+  @apply px-0 py-6;
 }
 
 .user-profile {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+  @apply flex items-center gap-3;
 }
 
 .sidebar-collapsed .user-profile {
-  justify-content: center;
-  gap: 8px;
+  @apply justify-center gap-2;
 }
 
 .sidebar-collapsed .user-profile button {
-  margin-left: 0;
+  @apply ml-0;
 }
 
 .user-avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: color-mix(in oklab, var(--primary) 18%, transparent);
+  @apply flex size-9 items-center justify-center rounded-full;
+  background: color-mix(in oklab, var(--color-primary) 18%, transparent);
 }
 
 .user-info {
-  flex: 1;
-  min-width: 0;
+  @apply flex-1 min-w-0;
 }
 
 .sidebar-collapsed .user-info {
-  display: none;
+  @apply hidden;
 }
 
 .user-name {
-  margin: 0;
-  font-size: 0.85rem;
-  font-weight: 500;
+  @apply m-0 text-sm font-medium;
 }
 
 .user-role {
-  margin: 0;
-  font-size: 0.7rem;
-  color: var(--text-muted);
+  @apply m-0 text-xs;
+  color: var(--color-muted-foreground);
 }
 
 /* Overlay */
 .sidebar-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 40;
+  @apply fixed inset-0 z-40;
   background: rgba(2, 6, 23, 0.6);
 }
 
 @media (min-width: 1024px) {
   .sidebar-overlay {
-    display: none;
+    @apply hidden;
   }
 }
 
 /* Main Content */
 .main-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-width: 0;
-  background: transparent;
+  @apply flex min-w-0 flex-1 flex-col bg-transparent;
 }
 
 /* Header */
 .main-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-3);
+  @apply flex items-center justify-between border-b p-6;
   background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), transparent);
-  border-bottom: 1px solid var(--divider);
+  border-color: var(--color-divider);
   backdrop-filter: blur(12px);
 }
 
 .header-left {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+  @apply flex items-center gap-4;
 }
 
 .sidebar-collapse-toggle {
-  display: none;
+  @apply hidden;
 }
 
 .sidebar-toggle {
-  display: none;
+  @apply hidden;
 }
 
 @media (max-width: 1023px) {
   .sidebar-toggle {
-    display: inline-flex;
+    @apply inline-flex;
   }
 }
 
 @media (min-width: 1024px) {
   .sidebar-collapse-toggle {
-    display: inline-flex;
+    @apply inline-flex;
   }
 }
 
 .search-container {
-  position: relative;
+  @apply relative;
 }
 
 .search-icon {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 16px;
-  height: 16px;
-  color: var(--text-muted);
+  @apply absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2;
+  color: var(--color-muted-foreground);
 }
 
 .search-input {
   width: 16rem;
   padding-left: 42px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
+  @apply rounded-xl border bg-transparent text-sm;
+  border-color: var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-foreground);
 }
 
 .search-input::placeholder {
-  color: var(--text-muted);
+  color: var(--color-muted-foreground);
 }
 
 .header-right {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+  @apply flex items-center gap-4;
 }
 
 .notification-btn {
-  position: relative;
+  @apply relative;
 }
 
 .notification-badge {
-  position: absolute;
-  top: -8px;
-  right: -6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 999px;
-  font-size: 0.65rem;
-  background: var(--primary);
-  color: var(--primary-foreground);
+  @apply absolute -right-1.5 -top-2 flex h-5 w-5 items-center justify-center rounded-full text-[0.65rem];
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
 }
 
 .status-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-muted);
-  font-size: 0.85rem;
+  @apply flex items-center gap-2 text-sm;
+  color: var(--color-muted-foreground);
 }
 
 .status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--success);
-  box-shadow: 0 0 0 2px color-mix(in oklab, var(--success) 25%, transparent);
+  @apply h-2.5 w-2.5 rounded-full;
+  background: var(--color-success);
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-success) 25%, transparent);
 }
 
 /* Page Content */
 .page-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--space-4);
+  @apply flex-1 overflow-y-auto p-8;
 }
 
 .page-content-inner {
-  max-width: 1280px;
-  margin: 0 auto;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
+  @apply mx-auto flex w-full max-w-[80rem] flex-col gap-6;
 }
 
 .onboarding-track {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px;
-  border-radius: 999px;
+  @apply inline-flex items-center gap-2 rounded-full border px-3 py-1.5;
   background: rgba(148, 163, 184, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.12);
   width: fit-content;
 }
 
 .onboarding-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.02em;
+  @apply inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium uppercase tracking-[0.02em];
   transition: background 0.2s ease;
 }
 
 .onboarding-pill__index {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  @apply inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border;
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
 .onboarding-pill--todo {
-  color: var(--text-muted);
+  color: var(--color-muted-foreground);
 }
 
 .onboarding-pill--todo .onboarding-pill__index {
@@ -417,23 +317,23 @@
 }
 
 .onboarding-pill--current {
-  color: var(--primary-foreground);
-  background: color-mix(in oklab, var(--primary) 20%, transparent);
+  color: var(--color-primary-foreground);
+  background: color-mix(in oklab, var(--color-primary) 20%, transparent);
 }
 
 .onboarding-pill--current .onboarding-pill__index {
-  background: var(--primary);
-  color: var(--primary-foreground);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
   border-color: transparent;
 }
 
 .onboarding-pill--done {
   color: #bbf7d0;
-  background: color-mix(in oklab, var(--success) 20%, transparent);
+  background: color-mix(in oklab, var(--color-success) 20%, transparent);
 }
 
 .onboarding-pill--done .onboarding-pill__index {
-  background: var(--success);
+  background: var(--color-success);
   color: #022c17;
   border-color: transparent;
 }
@@ -444,7 +344,7 @@
   }
 
   .page-content {
-    padding: var(--space-2);
+    @apply p-4;
   }
 }
 
@@ -454,6 +354,6 @@
 }
 
 .sidebar-nav::-webkit-scrollbar-thumb {
-  background: var(--surface-strong);
+  background: var(--color-surface-strong);
   border-radius: 999px;
 }

--- a/apps/web/src/features/leads/inbox/styles/tokens.css
+++ b/apps/web/src/features/leads/inbox/styles/tokens.css
@@ -1,6 +1,6 @@
 :root {
-  --inbox-glass-bg: rgba(148, 163, 184, 0.08);
-  --inbox-glass-border: rgba(148, 163, 184, 0.25);
+  --inbox-glass-bg: var(--color-surface-glass);
+  --inbox-glass-border: var(--color-surface-glass-border);
 }
 
 .inbox-glass-surface {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,2 +1,3 @@
+@import './styles/theme.css';
 @import 'tailwindcss';
 @import 'tw-animate-css';

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -1,0 +1,97 @@
+@theme {
+  --color-background: #0f172a;
+  --color-foreground: #f1f5f9;
+  --color-foreground-muted: #94a3b8;
+  --color-divider: rgba(124, 138, 163, 0.35);
+  --color-border: #7c8aa3;
+  --color-surface: rgba(124, 138, 163, 0.14);
+  --color-surface-strong: rgba(124, 138, 163, 0.22);
+  --color-surface-glass: rgba(148, 163, 184, 0.08);
+  --color-surface-glass-border: rgba(148, 163, 184, 0.25);
+
+  --color-primary: #6366f1;
+  --color-primary-foreground: #f8fafc;
+  --color-secondary: rgba(99, 102, 241, 0.12);
+  --color-secondary-foreground: #f1f5f9;
+  --color-accent: rgba(99, 102, 241, 0.18);
+  --color-accent-foreground: #f1f5f9;
+  --color-muted: rgba(148, 163, 184, 0.08);
+  --color-muted-foreground: #94a3b8;
+  --color-success: #22c55e;
+  --color-warning: #facc15;
+  --color-error: #ef4444;
+
+  --color-popover: rgba(124, 138, 163, 0.22);
+  --color-popover-foreground: #f1f5f9;
+  --color-card: rgba(124, 138, 163, 0.14);
+  --color-card-foreground: #f1f5f9;
+  --color-input: #7c8aa3;
+  --color-ring: #6366f1;
+
+  --color-chart-1: #6366f1;
+  --color-chart-2: #22d3ee;
+  --color-chart-3: #f97316;
+  --color-chart-4: #22c55e;
+  --color-chart-5: #facc15;
+
+  --color-sidebar: rgba(15, 23, 42, 0.96);
+  --color-sidebar-foreground: #f1f5f9;
+  --color-sidebar-primary: #6366f1;
+  --color-sidebar-primary-foreground: #f8fafc;
+  --color-sidebar-accent: rgba(148, 163, 184, 0.12);
+  --color-sidebar-accent-foreground: #f1f5f9;
+  --color-sidebar-border: rgba(255, 255, 255, 0.12);
+  --color-sidebar-ring: rgba(99, 102, 241, 0.4);
+
+  --spacing-2: 0.5rem;
+  --spacing-4: 1rem;
+  --spacing-6: 1.5rem;
+  --spacing-8: 2rem;
+
+  --radius-sm: 0.5rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+
+  --bg: var(--color-background);
+  --background: var(--color-background);
+  --foreground: var(--color-foreground);
+  --text: var(--color-foreground);
+  --text-muted: var(--color-muted-foreground);
+  --divider: var(--color-divider);
+  --border: var(--color-border);
+  --surface: var(--color-surface);
+  --surface-strong: var(--color-surface-strong);
+  --surface-glass: var(--color-surface-glass);
+  --surface-glass-border: var(--color-surface-glass-border);
+  --primary: var(--color-primary);
+  --primary-foreground: var(--color-primary-foreground);
+  --secondary: var(--color-secondary);
+  --secondary-foreground: var(--color-secondary-foreground);
+  --accent: var(--color-accent);
+  --accent-foreground: var(--color-accent-foreground);
+  --muted: var(--color-muted);
+  --muted-foreground: var(--color-muted-foreground);
+  --success: var(--color-success);
+  --warning: var(--color-warning);
+  --error: var(--color-error);
+  --card: var(--color-card);
+  --card-foreground: var(--color-card-foreground);
+  --popover: var(--color-popover);
+  --popover-foreground: var(--color-popover-foreground);
+  --input: var(--color-input);
+  --ring: var(--color-ring);
+  --sidebar: var(--color-sidebar);
+  --sidebar-foreground: var(--color-sidebar-foreground);
+  --sidebar-primary: var(--color-sidebar-primary);
+  --sidebar-primary-foreground: var(--color-sidebar-primary-foreground);
+  --sidebar-accent: var(--color-sidebar-accent);
+  --sidebar-accent-foreground: var(--color-sidebar-accent-foreground);
+  --sidebar-border: var(--color-sidebar-border);
+  --sidebar-ring: var(--color-sidebar-ring);
+  --space-1: var(--spacing-2);
+  --space-2: var(--spacing-4);
+  --space-3: var(--spacing-6);
+  --space-4: var(--spacing-8);
+  --radius: var(--radius-lg);
+}


### PR DESCRIPTION
## Summary
- add a shared @theme definition for web colors, radii, spacing, and semantic aliases and import it globally
- update base utilities to consume the central tokens while preserving glass and filter pill helpers
- refactor the layout stylesheet to use Tailwind apply utilities and shared tokens, and point inbox glass tokens at the theme values

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e654e5e57c8332b50af8bd86e90cba