### PR TITLE
Centralize web theme tokens for light and dark modes

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,121 +1,3 @@
-:root {
-  color-scheme: light;
-  --bg: #f8fafc;
-  --text: #0f172a;
-  --text-muted: #475569;
-  --divider: rgba(15, 23, 42, 0.08);
-  --primary: #4f46e5;
-  --primary-foreground: #eef2ff;
-  --success: #16a34a;
-  --warning: #d97706;
-  --error: #dc2626;
-  --surface: rgba(255, 255, 255, 0.78);
-  --surface-strong: rgba(255, 255, 255, 0.92);
-  --radius: 12px;
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --border: rgba(15, 23, 42, 0.12);
-  --space-1: 8px;
-  --space-2: 16px;
-  --space-3: 24px;
-  --space-4: 32px;
-  --input: rgba(15, 23, 42, 0.18);
-  --secondary: rgba(79, 70, 229, 0.1);
-  --secondary-foreground: var(--text);
-  --muted: rgba(148, 163, 184, 0.16);
-  --muted-foreground: var(--text-muted);
-  --accent: rgba(79, 70, 229, 0.16);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
-  --ring: rgba(79, 70, 229, 0.55);
-  --chart-1: #4f46e5;
-  --chart-2: #0ea5e9;
-  --chart-3: #f97316;
-  --chart-4: #16a34a;
-  --chart-5: #facc15;
-  --sidebar: rgba(255, 255, 255, 0.85);
-  --sidebar-foreground: var(--text);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: rgba(79, 70, 229, 0.1);
-  --sidebar-accent-foreground: var(--text);
-  --sidebar-border: rgba(15, 23, 42, 0.1);
-  --sidebar-ring: rgba(79, 70, 229, 0.25);
-
-  --background: var(--bg);
-  --foreground: var(--text);
-  --card: var(--surface);
-  --card-foreground: var(--text);
-  --popover: var(--surface-strong);
-  --popover-foreground: var(--text);
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
-}
-
-.dark {
-  color-scheme: dark;
-  --bg: #0f172a;
-  --text: #f1f5f9;
-  --text-muted: #94a3b8;
-  --divider: rgba(124, 138, 163, 0.35);
-  --primary: #6366f1;
-  --primary-foreground: #f8fafc;
-  --success: #22c55e;
-  --warning: #facc15;
-  --error: #ef4444;
-  --surface: rgba(124, 138, 163, 0.14);
-  --surface-strong: rgba(124, 138, 163, 0.22);
-  --border: #7c8aa3;
-  --input: #7c8aa3;
-  --secondary: rgba(99, 102, 241, 0.12);
-  --muted: rgba(148, 163, 184, 0.08);
-  --accent: rgba(99, 102, 241, 0.18);
-  --secondary-foreground: var(--text);
-  --muted-foreground: var(--text-muted);
-  --accent-foreground: var(--text);
-  --destructive: var(--error);
-  --ring: var(--primary);
-  --sidebar: rgba(15, 23, 42, 0.96);
-  --sidebar-foreground: var(--text);
-  --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: var(--primary-foreground);
-  --sidebar-accent: rgba(148, 163, 184, 0.12);
-  --sidebar-accent-foreground: var(--text);
-  --sidebar-border: rgba(255, 255, 255, 0.12);
-  --sidebar-ring: rgba(99, 102, 241, 0.4);
-}
-
 @layer base {
   * {
     border-color: var(--color-border);
@@ -125,10 +7,17 @@
   body {
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     color: var(--color-foreground);
-    background: radial-gradient(circle at top left, color-mix(in oklab, var(--color-primary) 15%, transparent), transparent 45%),
-      radial-gradient(circle at bottom right, color-mix(in oklab, var(--color-success) 8%, transparent), transparent 50%),
+    background: radial-gradient(
+        circle at top left,
+        color-mix(in oklab, var(--color-primary) 15%, transparent),
+        transparent 45%
+      ),
+      radial-gradient(
+        circle at bottom right,
+        color-mix(in oklab, var(--color-success) 8%, transparent),
+        transparent 50%
+      ),
       var(--color-background);
-    color: var(--foreground);
     background-color: var(--background);
     background-image:
       radial-gradient(circle at top left, color-mix(in srgb, var(--primary) 18%, transparent) 0%, transparent 50%),

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -10,6 +10,8 @@
   --color-error: #ef4444;
   --color-surface: rgba(124, 138, 163, 0.14);
   --color-surface-strong: rgba(124, 138, 163, 0.22);
+  --color-surface-glass: rgba(148, 163, 184, 0.08);
+  --color-surface-glass-border: rgba(148, 163, 184, 0.25);
   --color-border: #7c8aa3;
   --color-input: #7c8aa3;
   --color-ring: #6366f1;
@@ -33,20 +35,24 @@
   --color-sidebar-accent-foreground: #f1f5f9;
   --color-sidebar-border: rgba(255, 255, 255, 0.12);
   --color-sidebar-ring: rgba(99, 102, 241, 0.4);
-  --color-surface-glass: rgba(148, 163, 184, 0.08);
-  --color-surface-glass-border: rgba(148, 163, 184, 0.25);
+
+  --spacing-1: 0.25rem;
   --spacing-2: 0.5rem;
   --spacing-3: 0.75rem;
   --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
   --spacing-6: 1.5rem;
   --spacing-8: 2rem;
+
   --radius-sm: 0.5rem;
   --radius-md: 0.625rem;
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
+  --radius: var(--radius-lg);
+
   --bg: var(--color-background);
   --text: var(--color-foreground);
-  --text-muted: var(--color-muted-foreground);
+  --text-muted: var(--color-foreground-muted);
   --divider: var(--color-divider);
   --primary: var(--color-primary);
   --primary-foreground: var(--color-primary-foreground);
@@ -80,6 +86,13 @@
   --sidebar-accent-foreground: var(--color-sidebar-accent-foreground);
   --sidebar-border: var(--color-sidebar-border);
   --sidebar-ring: var(--color-sidebar-ring);
+
+  --background: var(--color-background);
+  --foreground: var(--color-foreground);
+  --card: var(--color-surface);
+  --card-foreground: var(--color-foreground);
+  --popover: var(--color-surface-strong);
+  --popover-foreground: var(--color-foreground);
   --color-card: var(--color-surface);
   --color-card-foreground: var(--color-foreground);
   --color-popover: var(--color-surface-strong);
@@ -87,5 +100,84 @@
   --color-secondary-muted: var(--color-muted);
   --color-secondary-muted-foreground: var(--color-muted-foreground);
   --color-sidebar-surface: var(--color-sidebar);
-  --radius: var(--radius-lg);
+}
+
+:root {
+  color-scheme: light;
+  --color-background: #f8fafc;
+  --color-foreground: #0f172a;
+  --color-foreground-muted: #475569;
+  --color-divider: rgba(15, 23, 42, 0.08);
+  --color-primary: #4f46e5;
+  --color-primary-foreground: #eef2ff;
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-error: #dc2626;
+  --color-surface: rgba(255, 255, 255, 0.78);
+  --color-surface-strong: rgba(255, 255, 255, 0.92);
+  --color-surface-glass: rgba(255, 255, 255, 0.85);
+  --color-surface-glass-border: rgba(15, 23, 42, 0.12);
+  --color-border: rgba(15, 23, 42, 0.12);
+  --color-input: rgba(15, 23, 42, 0.18);
+  --color-ring: rgba(79, 70, 229, 0.55);
+  --color-secondary: rgba(79, 70, 229, 0.1);
+  --color-secondary-foreground: #0f172a;
+  --color-muted: rgba(148, 163, 184, 0.16);
+  --color-muted-foreground: #475569;
+  --color-accent: rgba(79, 70, 229, 0.16);
+  --color-accent-foreground: #0f172a;
+  --color-destructive: #dc2626;
+  --color-chart-1: #4f46e5;
+  --color-chart-2: #0ea5e9;
+  --color-chart-3: #f97316;
+  --color-chart-4: #16a34a;
+  --color-chart-5: #facc15;
+  --color-sidebar: rgba(255, 255, 255, 0.85);
+  --color-sidebar-foreground: #0f172a;
+  --color-sidebar-primary: #4f46e5;
+  --color-sidebar-primary-foreground: #eef2ff;
+  --color-sidebar-accent: rgba(79, 70, 229, 0.1);
+  --color-sidebar-accent-foreground: #0f172a;
+  --color-sidebar-border: rgba(15, 23, 42, 0.1);
+  --color-sidebar-ring: rgba(79, 70, 229, 0.25);
+}
+
+.dark {
+  color-scheme: dark;
+  --color-background: #0f172a;
+  --color-foreground: #f1f5f9;
+  --color-foreground-muted: #94a3b8;
+  --color-divider: rgba(124, 138, 163, 0.35);
+  --color-primary: #6366f1;
+  --color-primary-foreground: #f8fafc;
+  --color-success: #22c55e;
+  --color-warning: #facc15;
+  --color-error: #ef4444;
+  --color-surface: rgba(124, 138, 163, 0.14);
+  --color-surface-strong: rgba(124, 138, 163, 0.22);
+  --color-surface-glass: rgba(148, 163, 184, 0.08);
+  --color-surface-glass-border: rgba(148, 163, 184, 0.25);
+  --color-border: #7c8aa3;
+  --color-input: #7c8aa3;
+  --color-ring: #6366f1;
+  --color-secondary: rgba(99, 102, 241, 0.12);
+  --color-secondary-foreground: #f1f5f9;
+  --color-muted: rgba(148, 163, 184, 0.08);
+  --color-muted-foreground: #94a3b8;
+  --color-accent: rgba(99, 102, 241, 0.18);
+  --color-accent-foreground: #f1f5f9;
+  --color-destructive: #ef4444;
+  --color-chart-1: #6366f1;
+  --color-chart-2: #22d3ee;
+  --color-chart-3: #f97316;
+  --color-chart-4: #22c55e;
+  --color-chart-5: #facc15;
+  --color-sidebar: rgba(15, 23, 42, 0.96);
+  --color-sidebar-foreground: #f1f5f9;
+  --color-sidebar-primary: #6366f1;
+  --color-sidebar-primary-foreground: #f8fafc;
+  --color-sidebar-accent: rgba(148, 163, 184, 0.12);
+  --color-sidebar-accent-foreground: #f1f5f9;
+  --color-sidebar-border: rgba(255, 255, 255, 0.12);
+  --color-sidebar-ring: rgba(99, 102, 241, 0.4);
 }


### PR DESCRIPTION
## Summary
- move color, spacing, and radius tokens into the shared theme using @theme defaults with light and dark scopes
- simplify App.css to consume centralized variables through base and utilities layers only

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68e65934eed08332bd1f82ce580b9d8f