### PR TITLE
Add useCallback import to layout component

### DIFF
--- a/apps/web/src/components/Layout.jsx
+++ b/apps/web/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Menu,
   Home,


### PR DESCRIPTION
## Summary
- add `useCallback` to the existing React hook imports for the layout component to prepare for future usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e677df82708332a16f557948632b8e