### PR TITLE
Refactor LeadInbox column scroll refs

### DIFF
--- a/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
+++ b/apps/web/src/features/leads/inbox/components/LeadInbox.jsx
@@ -440,6 +440,14 @@ export const LeadInbox = ({
     setInboxScrollParent((current) => (current === nextNode ? current : nextNode));
   }, []);
 
+  const registerColumnScrollAreaRef = useCallback(
+    (instance) => {
+      inboxScrollRef.current = instance;
+      handleColumnScrollAreaRef(instance);
+    },
+    [handleColumnScrollAreaRef]
+  );
+
   useEffect(() => {
     const previous = previousContextRef.current;
     const current = {
@@ -809,8 +817,7 @@ export const LeadInbox = ({
             </div>
 
             <ColumnScrollArea
-              ref={handleColumnScrollAreaRef}
-              ref={inboxScrollRef}
+              ref={registerColumnScrollAreaRef}
               className="flex-1 min-h-0"
               viewportClassName="space-y-5 px-5 pb-6 pr-6 pt-5"
             >


### PR DESCRIPTION
## Summary
- combine the ColumnScrollArea refs into a single callback that also keeps inboxScrollRef in sync
- ensure the inbox scroll parent state always receives the ColumnScrollArea viewport node

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67c425508833291b0d2063da4c3e1